### PR TITLE
Fix index out of range issue

### DIFF
--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -47,7 +47,7 @@ func getTillerReleases(tillerNS string) string {
 	lines := strings.Split(result, "\n")
 	for i, l := range lines {
 		if l != "" && !strings.HasPrefix(l, "NAME") && !strings.HasSuffix(l, "NAMESPACE") {
-			lines[i] = strings.TrimSuffix(l, "\n") + tillerNS
+			lines[i] = strings.TrimSuffix(l, "\n") + " " + tillerNS
 		}
 	}
 	return strings.Join(lines, "\n")


### PR DESCRIPTION
Before:
```
NAME                         	REVISION	UPDATED                 	STATUS  	CHART                             	NAMESPACE  
test-ingress                 	3       	Mon Apr 30 13:43:05 2018	DEPLOYED	k8s-ingress-0.1.1                 	kube-systemkube-system
```

When `helm_helpers.go:82` goes to pick up the 10th field, it doesn't exist because it's a part of field 9.  Adding a space ensures the columns don't run together.

After:
```
NAME                         	REVISION	UPDATED                 	STATUS  	CHART                             	NAMESPACE  
test-ingress                 	3       	Mon Apr 30 13:43:05 2018	DEPLOYED	k8s-ingress-0.1.1                 	kube-system kube-system
```