### PR TITLE
Use helm's json output

### DIFF
--- a/bindata.go
+++ b/bindata.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -163,6 +164,7 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"data": &bintree{nil, map[string]*bintree{
 		"role.yaml": &bintree{dataRoleYaml, map[string]*bintree{}},
@@ -215,4 +217,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-


### PR DESCRIPTION
This fixes #61 by changing the `helm_helpers` to use the `json` output from helm instead of relying on the table output, this should also make `helmsman` more resilient to `helm`'s out put changes.