### PR TITLE
adding helm diff to the decision maker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test: dependencies ## Run unit tests
 .PHONY: test
 
 cross: dependencies ## Create binaries for all OSs
-	@env CGO_ENABLED=0 gox -os '!freebsd !netbsd' -arch '!arm' -output 	"dist/{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags '-X main.Version=${TAG}-${DATE}'
+	@env CGO_ENABLED=0 gox -os '!freebsd !netbsd' -arch '!arm' -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags '-X main.Version=${TAG}-${DATE}'
 .PHONY: cross
 
 release: dependencies ## Generate a new release

--- a/dockerfile/dockerfile
+++ b/dockerfile/dockerfile
@@ -36,6 +36,7 @@ RUN apk --no-cache update \
     && mkdir -p ~/.helm/plugins \
     && helm plugin install https://github.com/hypnoglow/helm-s3.git \
     && helm plugin install https://github.com/nouney/helm-gcs \
+    && helm plugin install https://github.com/databus23/helm-diff \
     && rm -rf /tmp/linux-amd64
 
 COPY --from=kube /usr/local/bin/kubectl /bin/kubectl

--- a/init.go
+++ b/init.go
@@ -67,12 +67,16 @@ func init() {
 		logVersions()
 	}
 
+	if !toolExists("kubectl") {
+		logError("ERROR: kubectl is not installed/configured correctly. Aborting!")
+	}
+
 	if !toolExists("helm") {
 		logError("ERROR: helm is not installed/configured correctly. Aborting!")
 	}
 
-	if !toolExists("kubectl") {
-		logError("ERROR: kubectl is not installed/configured correctly. Aborting!")
+	if !helmPluginExists("diff") {
+		logError("ERROR: helm diff plugin is not installed/configured correctly. Aborting!")
 	}
 
 	// read the TOML/YAML desired state file
@@ -125,4 +129,22 @@ func toolExists(tool string) bool {
 	}
 
 	return true
+}
+
+// helmPluginExists returns true if the plugin is present in the environment and false otherwise.
+// It takes as input the plugin's name to check if it is recognizable or not. e.g. diff
+func helmPluginExists(plugin string) bool {
+	cmd := command{
+		Cmd:         "bash",
+		Args:        []string{"-c", "helm plugin list"},
+		Description: "validating that " + plugin + " is installed.",
+	}
+
+	exitCode, result := cmd.exec(debug, false)
+
+	if exitCode != 0 {
+		return false
+	}
+
+	return strings.Contains(result, plugin)
 }

--- a/kube_helpers.go
+++ b/kube_helpers.go
@@ -269,7 +269,7 @@ func createRole(namespace string) (bool, string) {
 // labelResource applies Helmsman specific labels to Helm's state resources (secrets/configmaps)
 func labelResource(r *release) {
 	if r.Enabled {
-		log.Println("INFO: applying Helmsman lables to [ " + r.Name + " ] in namespace [ " + r.Namespace + " ] ")
+		log.Println("INFO: applying Helmsman labels to [ " + r.Name + " ] in namespace [ " + r.Namespace + " ] ")
 		storageBackend := "configmap"
 
 		if s.Settings.StorageBackend == "secret" {

--- a/test_files/dockerfile
+++ b/test_files/dockerfile
@@ -15,6 +15,8 @@ RUN apk add --update --no-cache ca-certificates git \
     && curl -L http://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar zxv -C /tmp \
     && mv /tmp/linux-amd64/helm /usr/local/bin/helm \
     && chmod +x /usr/local/bin/helm \
+    && mkdir -p ~/.helm/plugins \
+    && helm plugin install https://github.com/databus23/helm-diff \
     && rm -rf /tmp/linux-amd64
 
 RUN go get github.com/goreleaser/goreleaser

--- a/utils.go
+++ b/utils.go
@@ -282,7 +282,6 @@ func notifySlack(content string, url string, failure bool, executing bool) bool 
 				"color": "` + color + `" ,
 				"pretext": "` + pretext + `",
 				"title": "` + content + `",
-				
 				"footer": "Helmsman ` + appVersion + `",
 				"ts": ` + strconv.FormatInt(t.Unix(), 10) + `
 			}


### PR DESCRIPTION
Here's an example output:
```
$ helmsman -f helmsman-common.yaml -f dev/helmsman-dev.yaml
 _          _
| |        | |
| |__   ___| |_ __ ___  ___ _ __ ___   __ _ _ __
| '_ \ / _ \ | '_ ` _ \/ __| '_ ` _ \ / _` | '_ \
| | | |  __/ | | | | | \__ \ | | | | | (_| | | | |
|_| |_|\___|_|_| |_| |_|___/_| |_| |_|\__,_|_| |_|version: v1.5.0
A Helm-Charts-as-Code tool.


2018/09/09 13:31:16 INFO: Parsed YAML [[ helmsman-common.yaml ]] successfully and found [ 0 ] apps.
2018/09/09 13:31:16 INFO: Parsed YAML [[ dev/helmsman-dev.yaml ]] successfully and found [ 1 ] apps.
2018/09/09 13:31:16 INFO: namespace validation -- Tiller is NOT desired to be deployed in namespace [ kube-system ].
2018/09/09 13:31:16 INFO: namespace validation -- Tiller is desired to be deployed WITHOUT TLS in namespace [ dev ].
2018/09/09 13:31:19 WARN: I could not create namespace [dev ]. It already exists. I am skipping this.
2018/09/09 13:31:20 WARN: I could not create namespace [kube-system ]. It already exists. I am skipping this.
2018/09/09 13:31:20 INFO: deploying Tiller in namespace [ dev ].
2018/09/09 13:31:28 INFO: checking what I need to do for your charts ...
2018/09/09 13:31:28 INFO: mapping the current helm state ...
dev, artifactory-artifactory, Ingress (extensions) has been added:
-
+ # Source: artifactory/templates/ingress.yaml
+ apiVersion: extensions/v1beta1
+ kind: Ingress
+ metadata:
+   name: artifactory-artifactory
+   labels:
+     app: artifactory
+     chart: artifactory-7.0.6
+     release: artifactory
+     heritage: Tiller
+   annotations:
+ spec:
+   rules:
+     - host: artifactory.domain.example
+       http:
+         paths:
+           - path: /
+             backend:
+               serviceName: artifactory-artifactory
+               servicePort: 8081

2018/09/09 13:31:34 INFO: checking if any Helmsman managed releases are no longer tracked by your desired state ...
2018/09/09 13:31:35 INFO: no untracked releases found.
2018/09/09 13:31:35 INFO: sorting the commands in the plan based on priorities (order flags) ...
----------------------
2018/09/09 13:31:35 INFO: Plan generated at: Sun Sep  9 2018 12:31:28
DECISION: release [ artifactory ] is desired to be enabled and is currently enabled. I will upgrade it! -- priority: -2
2018/09/09 13:31:35 INFO: completed successfully!
```