### PR TITLE
No fancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Alternatively YAML declaration is also acceptable [example yaml file](https://gi
 
 The desired state file (DSF) follows the [desired state specification](https://github.com/Praqma/helmsman/blob/master/docs/desired_state_specification.md).
 
-Helmsman sees what you desire, validates that your desire makes sense (e.g. that the charts you desire are available in the repos you defined), compares it with the current state of Helm and figures out what to do to make your desire come true. 
+Helmsman sees what you desire, validates that your desire makes sense (e.g. that the charts you desire are available in the repos you defined), compares it with the current state of Helm and figures out what to do to make your desire come true.
 
 To plan without executing:
 ``` $ helmsman -f example.toml ```
@@ -28,15 +28,15 @@ To show debugging details:
 
 # Features
 
-- **Built for CD**: Helmsman can be used as a docker image or a binary. 
+- **Built for CD**: Helmsman can be used as a docker image or a binary.
 - **Applications as code**: describe your desired applications and manage them from a single version-controlled declarative file.
 - **Suitable for Multitenant Clusters**: deploy Tiller in different namespaces with service accounts and TLS.
-- **Easy to use**: deep knowledge of Helm CLI and Kubectl is NOT mandatory to use Helmsman. 
-- **Plan, View, apply**: you can run Helmsman to generate and view a plan with/without executing it. 
+- **Easy to use**: deep knowledge of Helm CLI and Kubectl is NOT mandatory to use Helmsman.
+- **Plan, View, apply**: you can run Helmsman to generate and view a plan with/without executing it.
 - **Portable**: Helmsman can be used to manage charts deployments on any k8s cluster.
 - **Protect Namespaces/Releases**: you can define certain namespaces/releases to be protected against accidental human mistakes.
 - **Define the order of managing releases**: you can define the priorities at which releases are managed by helmsman (useful for dependencies).
-- **Idempotency**: As long your desired state file does not change, you can execute Helmsman several times and get the same result. 
+- **Idempotency**: As long your desired state file does not change, you can execute Helmsman several times and get the same result.
 - **Continue from failures**: In the case of partial deployment due to a specific chart deployment failure, fix your helm chart and execute Helmsman again without needing to rollback the partial successes first.
 
 # Install
@@ -78,7 +78,7 @@ Helmsman lets you:
 - [Override the defined namespaces to deploy all releases in a specific namespace](https://github.com/Praqma/helmsman/blob/master/docs/how_to/override_defined_namespaces.md)
 
 
-## Usage 
+## Usage
 
 Helmsman can be used in three different settings:
 

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -39,14 +39,14 @@ func ReadFile(bucketName string, filename string, outFile string) {
 	sess, err := session.NewSession()
 
 	if err != nil {
-		log.Fatal(aurora.Bold(aurora.Red("ERROR: Can't create AWS session: " + err.Error())))
+		log.Fatal(style.Bold(style.Red("ERROR: Can't create AWS session: " + err.Error())))
 	}
 	// create S3 download manger
 	downloader := s3manager.NewDownloader(sess)
 
 	file, err := os.Create(outFile)
 	if err != nil {
-		log.Fatal(aurora.Bold(aurora.Red("ERROR: Failed to open file " + outFile + ": " + err.Error())))
+		log.Fatal(style.Bold(style.Red("ERROR: Failed to open file " + outFile + ": " + err.Error())))
 	}
 
 	defer file.Close()
@@ -57,7 +57,7 @@ func ReadFile(bucketName string, filename string, outFile string) {
 			Key:    aws.String(filename),
 		})
 	if err != nil {
-		log.Fatal(aurora.Bold(aurora.Red("ERROR: Failed to download file  " + filename + " from S3: " + err.Error())))
+		log.Fatal(style.Bold(style.Red("ERROR: Failed to download file  " + filename + " from S3: " + err.Error())))
 	}
 
 	log.Println("INFO: Successfully downloaded " + filename + " from S3 as " + outFile)

--- a/decision_maker.go
+++ b/decision_maker.go
@@ -223,7 +223,6 @@ func diffRelease(r *release) string {
 		Description: "upgrading release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 
-	fmt.Println(cmd)
 	if exitCode, msg = cmd.exec(debug, verbose); exitCode != 0 {
 		logError("Command returned with exit code: " + string(exitCode) + ". And error message: " + msg)
 	} else {

--- a/decision_maker.go
+++ b/decision_maker.go
@@ -212,13 +212,18 @@ func inspectUpgradeScenario(r *release, rs releaseState) {
 func diffRelease(r *release) string {
 	exitCode := 0
 	msg := ""
+	colorFlag := ""
+	if noColors {
+		colorFlag = "--no-color "
+	}
 
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", "helm diff upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + r.Version + " " + getSetValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r)},
+		Args:        []string{"-c", "helm diff " + colorFlag + "upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + r.Version + " " + getSetValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r)},
 		Description: "upgrading release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 
+	fmt.Println(cmd)
 	if exitCode, msg = cmd.exec(debug, verbose); exitCode != 0 {
 		logError("Command returned with exit code: " + string(exitCode) + ". And error message: " + msg)
 	} else {

--- a/docs/best_practice.md
+++ b/docs/best_practice.md
@@ -2,7 +2,7 @@
 version: v1.0.0
 ---
 
-# Best Practice 
+# Best Practice
 
 When using Helmsman, we recommend the following best practices:
 
@@ -10,11 +10,11 @@ When using Helmsman, we recommend the following best practices:
 
 - Use environment variables to pass K8S connection secrets (password, certificates paths on the local system or AWS/GCS bucket urls and the API URI). This keeps all sensitive information out of your version controlled source code.
 
-- Define certain namespaces (e.g, production) as protected namespaces (supported in v1.0.0+) and deploy your production-ready releases there. 
+- Define certain namespaces (e.g, production) as protected namespaces (supported in v1.0.0+) and deploy your production-ready releases there.
 
-- If you use multiple desired state files (DSF) with the same cluster, make sure your namespace protection definitions are identical across all DSFs. 
+- If you use multiple desired state files (DSF) with the same cluster, make sure your namespace protection definitions are identical across all DSFs.
 
-- Don't maintain the same release in multiple DSFs. 
+- Don't maintain the same release in multiple DSFs.
 
 - While the decision on how many DSFs to use and what each can contain is up to you and depends on your case, we recommend coming up with your own rule for how to split them.
 

--- a/docs/how_to/define_namespaces.md
+++ b/docs/how_to/define_namespaces.md
@@ -31,11 +31,11 @@ namespaces:
 
 ## Using your existing Tillers (available from v1.6.0)
 
-If you would like to use custom configuration when deploying your Tiller, you can do that before using Helmsman and then use the `useTiller` option in your namespace definition. 
+If you would like to use custom configuration when deploying your Tiller, you can do that before using Helmsman and then use the `useTiller` option in your namespace definition.
 
 This will allow Helmsman to use your existing Tiller as it is. Note that you can't set both `useTiller` and `installTiller` to true at the same time.
 
-```toml 
+```toml
 [namespaces]
 [namespaces.production]
   useTiller = true
@@ -47,7 +47,7 @@ namespaces:
     useTiller: true
 ```
 
-## Deploying Tiller into namespaces 
+## Deploying Tiller into namespaces
 
 As of `v1.2.0-rc`, you can instruct Helmsman to deploy Tiller into specific namespaces (with or without TLS).
 
@@ -79,7 +79,7 @@ namespaces:
     clientKey: "s3://mybucket/mydir/helm.key.pem"
 ```
 
-### Preventing Tiller deployment in kube-system 
+### Preventing Tiller deployment in kube-system
 
 By default Tiller will be deployed into `kube-system` even if you don't define kube-system in the namespaces section. To prevent this, simply add `kube-system` into your namespaces section. Since `installTiller` for namespaces is by default false, Helmsman will not deploy Tiller in `kube-system`.
 
@@ -102,19 +102,19 @@ You can then tell Helmsman to deploy specific releases in a specific namespace:
 [apps]
 
     [apps.jenkins]
-    name = "jenkins" 
+    name = "jenkins"
     description = "jenkins"
     namespace = "production" # pointing to the namespace defined above
-    enabled = true 
-    chart = "stable/jenkins" 
-    version = "0.9.1" 
-    valuesFile = "" 
-    purge = false 
-    test = true  
+    enabled = true
+    chart = "stable/jenkins"
+    version = "0.9.1"
+    valuesFile = ""
+    purge = false
+    test = true
 
 ...
 
-``` 
+```
 
 ```yaml
 ...
@@ -134,5 +134,5 @@ apps:
 
 ```
 
-In the above example, `Jenkins` will be deployed in the production namespace using the Tiller deployed in the production namespace. If the production namespace was not configured to have Tiller deployed there, Jenkins will be deployed using the Tiller in `kube-system`. 
+In the above example, `Jenkins` will be deployed in the production namespace using the Tiller deployed in the production namespace. If the production namespace was not configured to have Tiller deployed there, Jenkins will be deployed using the Tiller in `kube-system`.
 

--- a/docs/how_to/move_charts_across_namespaces.md
+++ b/docs/how_to/move_charts_across_namespaces.md
@@ -19,19 +19,19 @@ If you have a workflow for testing a release first in the `staging` namespace th
 [apps]
 
     [apps.jenkins]
-    name = "jenkins" 
+    name = "jenkins"
     description = "jenkins"
     namespace = "staging" # this is where it is deployed
-    enabled = true 
-    chart = "stable/jenkins" 
-    version = "0.9.1" 
-    valuesFile = "" 
-    purge = false 
-    test = true  
+    enabled = true
+    chart = "stable/jenkins"
+    version = "0.9.1"
+    valuesFile = ""
+    purge = false
+    test = true
 
 ...
 
-``` 
+```
 
 ```yaml
 ...
@@ -68,19 +68,19 @@ Then if you change the namespace key for jenkins:
 [apps]
 
     [apps.jenkins]
-    name = "jenkins" 
+    name = "jenkins"
     description = "jenkins"
     namespace = "production" # we want to move it to production
-    enabled = true 
-    chart = "stable/jenkins" 
-    version = "0.9.1" 
-    valuesFile = "" 
-    purge = false 
-    test = true  
+    enabled = true
+    chart = "stable/jenkins"
+    version = "0.9.1"
+    valuesFile = ""
+    purge = false
+    test = true
 
 ...
 
-``` 
+```
 
 ```yaml
 ...

--- a/docs/how_to/multiple_value_files.md
+++ b/docs/how_to/multiple_value_files.md
@@ -26,9 +26,9 @@ You can include multiple yaml value files to separate configuration for differen
     [apps.jenkins-test]
     name = "jenkins-test" # should be unique across all apps
     description = "test release of jenkins, testing xyz feature"
-    namespace = "staging" 
-    enabled = true 
-    chart = "stable/jenkins" 
+    namespace = "staging"
+    enabled = true
+    chart = "stable/jenkins"
     version = "0.9.1" # chart version
     valuesFiles = [
         "../my-jenkins-common-values.yaml",

--- a/docs/how_to/multitenant_clusters_guide.md
+++ b/docs/how_to/multitenant_clusters_guide.md
@@ -4,7 +4,7 @@ version: v1.5.0
 
 # Multitenant Clusters Guide
 
-This guide helps you use Helmsman to secure your Helm deployment with service accounts and TLS. 
+This guide helps you use Helmsman to secure your Helm deployment with service accounts and TLS.
 
 >Checkout Helm's [security guide](https://github.com/kubernetes/helm/blob/master/docs/securing_installation.md)
 
@@ -42,13 +42,13 @@ namespaces:
 
 ```
 
-By default Tiller will be deployed into `kube-system` even if you don't define kube-system in the namespaces section. To prevent deploying Tiller into `kube-system, you need to explicitly add `kube-system` in your defined namespaces. See the [namespaces guide](define_namespaces.md#preventing_tiller_deployment_in_kube-system) for an example. 
+By default Tiller will be deployed into `kube-system` even if you don't define kube-system in the namespaces section. To prevent deploying Tiller into `kube-system, you need to explicitly add `kube-system` in your defined namespaces. See the [namespaces guide](define_namespaces.md#preventing_tiller_deployment_in_kube-system) for an example.
 
-## Deploying Tiller with a service account 
+## Deploying Tiller with a service account
 
 For K8S clusters with RBAC enabled, you will need to initialize Helm with a service account. Check [Helm's RBAC guide](https://github.com/kubernetes/helm/blob/master/docs/rbac.md).
 
-Helmsman lets you deploy each of the Tillers with a different k8s service account Or with a default service account of your choice. 
+Helmsman lets you deploy each of the Tillers with a different k8s service account Or with a default service account of your choice.
 
 ```toml
 
@@ -63,7 +63,7 @@ serviceAccount = "default-tiller-sa"
 
     [namespaces.production]
     installTiller = true
-    
+
     [namespaces.developer1]
     installTiller = true
     tillerServiceAccount = "dev1-sa"
@@ -104,8 +104,8 @@ If `tillerServiceAccount` is not defined, the following options are considered:
   2. Helmsman creates the service account in that namespace and binds it to a role. If the namespace is kube-system, the service account is bound to `cluster-admin` clusterrole. Otherwise, a new role called `helmsman-tiller` is created in that namespace and only gives access to that namespace.
 
 
-In the example above, namespaces `staging, developer1 & developer2` will have Tiller deployed with different service accounts. 
-The `production` namespace ,however, will be deployed using the `default-tiller-sa` service account defined in the `settings` section -assuming it exists in the production namespace-. If this one is not defined, Helmsman creates a new service account and binds it to a new role that only gives access to the `production` namespace. 
+In the example above, namespaces `staging, developer1 & developer2` will have Tiller deployed with different service accounts.
+The `production` namespace ,however, will be deployed using the `default-tiller-sa` service account defined in the `settings` section -assuming it exists in the production namespace-. If this one is not defined, Helmsman creates a new service account and binds it to a new role that only gives access to the `production` namespace.
 
 ## Deploying Tiller with TLS enabled
 
@@ -115,7 +115,7 @@ In a multitenant setting, it is also recommended to deploy Tiller with TLS enabl
 
 [namespaces]
     [namespaces.kube-system]
-    installTiller = false # has no effect. Tiller is always deployed in kube-system 
+    installTiller = false # has no effect. Tiller is always deployed in kube-system
     caCert = "secrets/kube-system/ca.cert.pem"
     tillerCert = "secrets/kube-system/tiller.cert.pem"
     tillerKey = "$TILLER_KEY" # where TILLER_KEY=secrets/kube-system/tiller.key.pem

--- a/docs/how_to/protect_namespaces_and_releases.md
+++ b/docs/how_to/protect_namespaces_and_releases.md
@@ -2,15 +2,15 @@
 version: v1.3.0-rc
 ---
 
-# Namespace and Release Protection 
+# Namespace and Release Protection
 
-Since helmsman is used with version controlled code and is often configured to be triggered as part of a CI pipeline, accidental mistakes could happen by the user (e.g, disabling a production application and taking out of service as a result of a mistaken change in the desired state file). 
+Since helmsman is used with version controlled code and is often configured to be triggered as part of a CI pipeline, accidental mistakes could happen by the user (e.g, disabling a production application and taking out of service as a result of a mistaken change in the desired state file).
 
-Helmsman provides the `plan` flag which helps you see the actions that it will take based on your desired state file before actually doing them. We recommend to use a `plan-hold-approve` pipeline when using helmsman with production clusters. 
+Helmsman provides the `plan` flag which helps you see the actions that it will take based on your desired state file before actually doing them. We recommend to use a `plan-hold-approve` pipeline when using helmsman with production clusters.
 
-As of version v1.0.0, helmsman provides a fine-grained mechanism to protect releases/namespaces from accidental desired state file changes. 
+As of version v1.0.0, helmsman provides a fine-grained mechanism to protect releases/namespaces from accidental desired state file changes.
 
-## Protection definition 
+## Protection definition
 
 - When a release (application) is protected, it CANNOT:
     - deleted
@@ -20,14 +20,14 @@ As of version v1.0.0, helmsman provides a fine-grained mechanism to protect rele
 - A release CAN be moved into protection from a non-protected state.
 - If a protected release need to be updated/changed or even deleted, this is possible, but the protection has to be removed first (i.e. remove the namespace/release from the protected state). This explained further below.
 
-> A release is an instance (installation) of an application which has been packaged as a helm chart. 
+> A release is an instance (installation) of an application which has been packaged as a helm chart.
 
 ## Protection mechanism
 Protection is supported in two forms:
 
 - **Namespace-level Protection**: is defined at the namespace level. A namespace can be declaratively defined to be protected in the desired state file as in the example below:
 
-```toml 
+```toml
 [namespaces]
   [namespaces.staging]
   protected = false
@@ -42,15 +42,15 @@ Protection is supported in two forms:
 [apps]
 
     [apps.jenkins]
-    name = "jenkins" 
+    name = "jenkins"
     description = "jenkins"
-    namespace = "staging" 
-    enabled = true 
-    chart = "stable/jenkins" 
-    version = "0.9.1" 
-    valuesFile = "" 
-    purge = false 
-    test = false 
+    namespace = "staging"
+    enabled = true
+    chart = "stable/jenkins"
+    version = "0.9.1"
+    valuesFile = ""
+    purge = false
+    test = false
     protected = true # defining this release to be protected.
 ```
 

--- a/docs/how_to/run_helmsman_in_ci.md
+++ b/docs/how_to/run_helmsman_in_ci.md
@@ -4,13 +4,13 @@ version: v1.3.0-rc
 
 # Run Helmsman in CI
 
-You can run Helmsman as a job in your CI system using the [helmsman docker image](https://hub.docker.com/r/praqma/helmsman/). 
+You can run Helmsman as a job in your CI system using the [helmsman docker image](https://hub.docker.com/r/praqma/helmsman/).
 The following example is a `config.yml` file for CircleCI but can be replicated for other CI systems.
 
 ```
 version: 2
 jobs:
-    
+
     deploy-apps:
       docker:
         - image: praqma/helmsman:v1.5.0
@@ -26,7 +26,7 @@ workflows:
   build:
     jobs:
       - deploy-apps
-``` 
+```
 
 > IMPORTANT: If your CI build logs are publicly readable, don't use the `--verbose` flag as logs any secrets being passed from env vars to the helm charts.
 

--- a/docs/how_to/run_helmsman_with_minikube.md
+++ b/docs/how_to/run_helmsman_with_minikube.md
@@ -11,7 +11,7 @@ org = "orgX"
 maintainer = "k8s-admin"
 
 [settings]
-kubeContext = "minikube" 
+kubeContext = "minikube"
 
 [namespaces]
 [namespaces.staging]
@@ -22,27 +22,27 @@ stable = "https://kubernetes-charts.storage.googleapis.com"
 [apps]
 
     [apps.jenkins]
-    name = "jenkins" 
+    name = "jenkins"
     description = "jenkins"
-    namespace = "staging" 
-    enabled = true 
-    chart = "stable/jenkins" 
-    version = "0.9.1" 
-    valuesFile = "" 
-    purge = false 
-    test = false 
+    namespace = "staging"
+    enabled = true
+    chart = "stable/jenkins"
+    version = "0.9.1"
+    valuesFile = ""
+    purge = false
+    test = false
 
 
     [apps.artifactory]
-    name = "artifactory" 
+    name = "artifactory"
     description = "artifactory"
-    namespace = "staging" 
-    enabled = true 
-    chart = "stable/artifactory" 
-    version = "6.2.0" 
-    valuesFile = "" 
-    purge = false 
-    test = false 
+    namespace = "staging"
+    enabled = true
+    chart = "stable/artifactory"
+    version = "6.2.0"
+    valuesFile = ""
+    purge = false
+    test = false
 ```
 
 ```yaml

--- a/docs/how_to/send_slack_notifications_from_helmsman.md
+++ b/docs/how_to/send_slack_notifications_from_helmsman.md
@@ -6,17 +6,17 @@ version: v1.5.0
 
 Starting from v1.4.0-rc, Helmsman can send slack notifications to a channel of your choice. To enable the notifications, simply add a `slack webhook` in the `settings` section of your desired state file. The webhook URL can be passed directly or from an environment variable.
 
-```toml 
+```toml
 [settings]
 ...
-slackWebhook = $MY_SLACK_WEBHOOK 
+slackWebhook = $MY_SLACK_WEBHOOK
 ```
 
 ```yaml
 settings:
   ...
   #slackWebhook : "$MY_SLACK_WEBHOOK"
-``` 
+```
 
 ## Getting a Slack Webhook URL
 

--- a/docs/how_to/test_charts.md
+++ b/docs/how_to/test_charts.md
@@ -11,15 +11,15 @@ You can specify that you would like a chart to be tested whenever it is installe
 [apps]
 
     [apps.jenkins]
-    name = "jenkins" 
+    name = "jenkins"
     description = "jenkins"
-    namespace = "staging" 
-    enabled = true 
-    chart = "stable/jenkins" 
-    version = "0.9.1" 
-    valuesFile = "" 
-    purge = false 
-    test = true  # setting this to true, means you want the charts tests to be run on this release when it is installed. 
+    namespace = "staging"
+    enabled = true
+    chart = "stable/jenkins"
+    version = "0.9.1"
+    valuesFile = ""
+    purge = false
+    test = true  # setting this to true, means you want the charts tests to be run on this release when it is installed.
 
 ...
 

--- a/docs/migrating_to_v1.4.0-rc.md
+++ b/docs/migrating_to_v1.4.0-rc.md
@@ -4,5 +4,5 @@ This document highlights the main changes between Helmsman v1.4.0-rc and the old
 
 - Helmsman v1.4.0-rc tracks the releases it manages by applying specific labels to their Helm state (stored in Helm's configured backend storage). For smooth transition when upgrading to v1.4.0-rc, you should run `helmsman -f <your desired state file> --apply-labels` once. This will label all releases from your desired state as with a `MANAGED-BY=Helmsman` label. The `--apply-labels`is safe to run multiple times.
 
-- After each run, Helmsman v1.4.0-rc looks for, and deletes any releases with the `MANAGED-BY=Helmsman` label which are no longer existing in your desired state. This means that **deleting/commenting out an app from your desired state file will result in its deletion**. You can disable this cleanup by adding the flag `--keep-untracked-releases` to your Helmsman commands.  
+- After each run, Helmsman v1.4.0-rc looks for, and deletes any releases with the `MANAGED-BY=Helmsman` label which are no longer existing in your desired state. This means that **deleting/commenting out an app from your desired state file will result in its deletion**. You can disable this cleanup by adding the flag `--keep-untracked-releases` to your Helmsman commands.
 

--- a/docs/why_helmsman.md
+++ b/docs/why_helmsman.md
@@ -4,33 +4,33 @@ version: v0.1.2
 
 # Why Helmsman?
 
-This document describes the reasoning and need behind the inception of Helmsman. 
+This document describes the reasoning and need behind the inception of Helmsman.
 
 ## Before Helm
 
-Helmsman was created with continous deployment in mind. 
-When we started using k8s, we deployed applications on our cluster directly from k8s manifest files. Initially, we had a custom shell script added to our CI system to deploy the k8s resources on the cluster. That script could only create the k8s resources from the manifest files. Soon we needed to have a more flexible way to dynamically create/delete those resources. We structured our git repo and used custom file names (adding enabled or disabled into file names) and updated the shell script accordingly. It did not take long before we realized that this does not scale and is difficult to maintain. 
+Helmsman was created with continous deployment in mind.
+When we started using k8s, we deployed applications on our cluster directly from k8s manifest files. Initially, we had a custom shell script added to our CI system to deploy the k8s resources on the cluster. That script could only create the k8s resources from the manifest files. Soon we needed to have a more flexible way to dynamically create/delete those resources. We structured our git repo and used custom file names (adding enabled or disabled into file names) and updated the shell script accordingly. It did not take long before we realized that this does not scale and is difficult to maintain.
 
 ![CI-pipeline-before-helm](images/CI-pipeline-before-helm.jpg)
 
 ## Helm to the rescue?
 
-While looking for solutions for managing the growing number of k8s manifest files from a CI pipeline, we came to know about Helm and quickly releaized its potential. By creating Helm charts, we packaged related k8s manifests together into a single entity "a chart". This reduced the amount of files the CI script has to deal with. However, all the CI shell script could do is package a chart and install/upgrade it in our k8s cluster whenever a new commit is done into the chart's files in git. 
+While looking for solutions for managing the growing number of k8s manifest files from a CI pipeline, we came to know about Helm and quickly releaized its potential. By creating Helm charts, we packaged related k8s manifests together into a single entity "a chart". This reduced the amount of files the CI script has to deal with. However, all the CI shell script could do is package a chart and install/upgrade it in our k8s cluster whenever a new commit is done into the chart's files in git.
 
 ![CI-pipeline-after-helm](images/CI-pipeline-after-helm.jpg)
 
 But there were a couple of issues here:
 1. Helm has more to it than package and install. Operations such as rollback, running chart tests etc. are only doable from the Helm's CLI client.
-2. You have to keep updating your CI script everytime you add a chart to k8s. 
+2. You have to keep updating your CI script everytime you add a chart to k8s.
 3. What if you want to do the same on another cluster? you will have to replicate your CI pipeline and possibly change your CI script accordingly.
 
-We have also decided to split the Helm charts development from the git repositories where they are used. This is simply to let us develop the charts independently from the projects where we used them and to allow us to reuse them in different projects. 
+We have also decided to split the Helm charts development from the git repositories where they are used. This is simply to let us develop the charts independently from the projects where we used them and to allow us to reuse them in different projects.
 
 With all this in mind, we needed a flexible and dynamic solution that can let us deploy and manage Helm charts into multiple k8s cluster independently and with minimum human intervention. Such solution should be generic enough to be reusable for many different projects/cluster. And this is where Helmsman was born!
 
 ## The Helmsman way
 
-In English, [Helmsman](https://www.merriam-webster.com/dictionary/helmsman) is the person at the helm (in a ship). In k8s and Helm context, Helmsman holds the Helm and maintains your Helm charts' lifecycle in your k8s cluster(s). Helmsman gets its directions to navigate from a [declarative file](desired_state_specification.md) maintained by the user (k8s admin). 
+In English, [Helmsman](https://www.merriam-webster.com/dictionary/helmsman) is the person at the helm (in a ship). In k8s and Helm context, Helmsman holds the Helm and maintains your Helm charts' lifecycle in your k8s cluster(s). Helmsman gets its directions to navigate from a [declarative file](desired_state_specification.md) maintained by the user (k8s admin).
 
 > Although knowledge about Helm and K8S is highly beneficial, such knowledge is NOT required to use Helmsman.
 

--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -28,7 +28,7 @@ func Auth() bool {
 		err := ioutil.WriteFile(credFile, d, 0644)
 
 		if err != nil {
-			log.Fatal(aurora.Bold(aurora.Red("ERROR: Cannot create credentials file: " + err.Error())))
+			log.Fatal(style.Bold(style.Red("ERROR: Cannot create credentials file: " + err.Error())))
 		}
 
 		os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credFile)
@@ -40,13 +40,13 @@ func Auth() bool {
 // ReadFile reads a file from storage bucket and saves it in a desired location.
 func ReadFile(bucketName string, filename string, outFile string) {
 	if !Auth() {
-		log.Fatal(aurora.Bold(aurora.Red("ERROR: Failed to find the GCLOUD_CREDENTIALS env var. Please make sure it is set in the environment.")))
+		log.Fatal(style.Bold(style.Red("ERROR: Failed to find the GCLOUD_CREDENTIALS env var. Please make sure it is set in the environment.")))
 	}
 
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)
 	if err != nil {
-		log.Fatal(aurora.Bold(aurora.Red("ERROR: Failed to configure Storage bucket: " + err.Error())))
+		log.Fatal(style.Bold(style.Red("ERROR: Failed to configure Storage bucket: " + err.Error())))
 	}
 	storageBucket := client.Bucket(bucketName)
 
@@ -56,7 +56,7 @@ func ReadFile(bucketName string, filename string, outFile string) {
 	// Read the object.
 	r, err := obj.NewReader(ctx)
 	if err != nil {
-		log.Fatal(aurora.Bold(aurora.Red("ERROR: Failed to create object reader: " + err.Error())))
+		log.Fatal(style.Bold(style.Red("ERROR: Failed to create object reader: " + err.Error())))
 	}
 	defer r.Close()
 
@@ -64,14 +64,14 @@ func ReadFile(bucketName string, filename string, outFile string) {
 	var writers []io.Writer
 	file, err := os.Create(outFile)
 	if err != nil {
-		log.Fatal(aurora.Bold(aurora.Red("ERROR: Failed to create an output file: " + err.Error())))
+		log.Fatal(style.Bold(style.Red("ERROR: Failed to create an output file: " + err.Error())))
 	}
 	writers = append(writers, file)
 	defer file.Close()
 
 	dest := io.MultiWriter(writers...)
 	if _, err := io.Copy(dest, r); err != nil {
-		log.Fatal(aurora.Bold(aurora.Red("ERROR: Failed to read object content: " + err.Error())))
+		log.Fatal(style.Bold(style.Red("ERROR: Failed to read object content: " + err.Error())))
 	}
 	log.Println("INFO: Successfully downloaded " + filename + " from GCS as " + outFile)
 }

--- a/init.go
+++ b/init.go
@@ -9,7 +9,11 @@ import (
 
 	"github.com/imdario/mergo"
 	"github.com/joho/godotenv"
+	"github.com/logrusorgru/aurora"
 )
+
+// colorizer
+var style aurora.Aurora
 
 const (
 	banner = " _          _ \n" +
@@ -34,12 +38,21 @@ func init() {
 	flag.BoolVar(&v, "v", false, "show the version")
 	flag.BoolVar(&verbose, "verbose", false, "show verbose execution logs")
 	flag.BoolVar(&noBanner, "no-banner", false, "don't show the banner")
+	flag.BoolVar(&noColors, "no-color", false, "don't use colors")
+	flag.BoolVar(&noFancy, "no-fancy", false, "don't display the banner and don't use colors")
 	flag.StringVar(&nsOverride, "ns-override", "", "override defined namespaces with this one")
 	flag.BoolVar(&skipValidation, "skip-validation", false, "skip desired state validation")
 	flag.BoolVar(&applyLabels, "apply-labels", false, "apply Helmsman labels to Helm state for all defined apps.")
 	flag.BoolVar(&keepUntrackedReleases, "keep-untracked-releases", false, "keep releases that are managed by Helmsman and are no longer tracked in your desired state.")
 
 	flag.Parse()
+
+	if noFancy {
+		noColors = true
+		noBanner = true
+	}
+
+	style = aurora.NewAurora(!noColors)
 
 	if !noBanner {
 		fmt.Println(banner + "version: " + appVersion + "\n" + slogan)

--- a/init.go
+++ b/init.go
@@ -25,6 +25,15 @@ const (
 	slogan = "A Helm-Charts-as-Code tool.\n\n"
 )
 
+func printUsage() {
+	fmt.Println(banner + "\n")
+	fmt.Println("Helmsman version: " + appVersion)
+	fmt.Println("Helmsman is a Helm Charts as Code tool which allows you to automate the deployment/management of your Helm charts.")
+	fmt.Println()
+	fmt.Println("Usage: helmsman [options]")
+	flag.PrintDefaults()
+}
+
 // init is executed after all package vars are initialized [before the main() func in this case].
 // It checks if Helm and Kubectl exist and configures: the connection to the k8s cluster, helm repos, namespaces, etc.
 func init() {
@@ -34,7 +43,6 @@ func init() {
 	flag.BoolVar(&apply, "apply", false, "apply the plan directly")
 	flag.BoolVar(&debug, "debug", false, "show the execution logs")
 	flag.BoolVar(&dryRun, "dry-run", false, "apply the dry-run option for helm commands.")
-	flag.BoolVar(&help, "help", false, "show Helmsman help")
 	flag.BoolVar(&v, "v", false, "show the version")
 	flag.BoolVar(&verbose, "verbose", false, "show verbose execution logs")
 	flag.BoolVar(&noBanner, "no-banner", false, "don't show the banner")
@@ -45,6 +53,7 @@ func init() {
 	flag.BoolVar(&applyLabels, "apply-labels", false, "apply Helmsman labels to Helm state for all defined apps.")
 	flag.BoolVar(&keepUntrackedReleases, "keep-untracked-releases", false, "keep releases that are managed by Helmsman and are no longer tracked in your desired state.")
 
+	flag.Usage = printUsage
 	flag.Parse()
 
 	if noFancy {
@@ -55,7 +64,7 @@ func init() {
 	style = aurora.NewAurora(!noColors)
 
 	if !noBanner {
-		fmt.Println(banner + "version: " + appVersion + "\n" + slogan)
+		fmt.Println(banner + " version: " + appVersion + "\n" + slogan)
 	}
 
 	if dryRun && apply {
@@ -78,11 +87,6 @@ func init() {
 
 	if v {
 		fmt.Println("Helmsman version: " + appVersion)
-		os.Exit(0)
-	}
-
-	if help {
-		printHelp()
 		os.Exit(0)
 	}
 

--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ var debug bool
 var files stringArray
 var envFiles stringArray
 var apply bool
-var help bool
 var v bool
 var verbose bool
 var noBanner bool

--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ var help bool
 var v bool
 var verbose bool
 var noBanner bool
+var noColors bool
+var noFancy bool
 var nsOverride string
 var checkCleanup bool
 var skipValidation bool

--- a/plan.go
+++ b/plan.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/logrusorgru/aurora"
 )
 
 // orderedDecision type representing a Decision and it's priority weight
@@ -76,7 +74,7 @@ func (p plan) execPlan() {
 		if exitCode, msg := cmd.Command.exec(debug, verbose); exitCode != 0 {
 			logError("Command returned with exit code: " + string(exitCode) + ". And error message: " + msg)
 		} else {
-			log.Println(aurora.Cyan(msg))
+			log.Println(style.Cyan(msg))
 			if cmd.targetRelease != nil && !dryRun {
 				labelResource(cmd.targetRelease)
 			}
@@ -98,9 +96,9 @@ func (p plan) printPlanCmds() {
 // printPlan prints the decisions made in a plan.
 func (p plan) printPlan() {
 	fmt.Println("----------------------")
-	log.Println(aurora.Bold(aurora.Green("INFO: Plan generated at: " + p.Created.Format("Mon Jan _2 2006 15:04:05"))))
+	log.Println(style.Bold(style.Green("INFO: Plan generated at: " + p.Created.Format("Mon Jan _2 2006 15:04:05"))))
 	for _, decision := range p.Decisions {
-		fmt.Println(aurora.Green(decision.Description + " -- priority: " + strconv.Itoa(decision.Priority)))
+		fmt.Println(style.Green(decision.Description + " -- priority: " + strconv.Itoa(decision.Priority)))
 	}
 }
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -3,10 +3,9 @@
 > If you are already using an older version of Helmsman than v1.4.0-rc, please read the changes below carefully and follow the upgrade guide [here](docs/migrating_to_v1.4.0-rc.md)
 
 - Adding support for helm secrets plugin (thanks to @luisdavim). issue #54
-- Adding support for using helm diff to determine when upgrades are needed and show the diff. 
+- Adding support for using helm diff to determine when upgrades are needed and show the diff.
 - Allowing env vars to be loaded from files using Godotenv (thanks to @luisdavim)
-- Adding `--dry-run` option in Helmsman to perform a helm dry-run operation. Issues #77 #60 
+- Adding `--dry-run` option in Helmsman to perform a helm dry-run operation. Issues #77 #60
 - Adding `useTiller` option in namespaces definitions to use existing Tillers. Issue #71
-- Other minor code improvements and color coded output.  
+- Other minor code improvements and color coded output.
 
-    

--- a/test_files/invalid_example.toml
+++ b/test_files/invalid_example.toml
@@ -6,10 +6,10 @@ maintainer = "k8s-admin"
 [certificates]
 
 [settings]
-kubeContext =  
+kubeContext =
 
 [namespaces]
-staging = "staging" 
+staging = "staging"
 production = "default"
 
 [helmRepos]

--- a/test_files/invalid_example.yaml
+++ b/test_files/invalid_example.yaml
@@ -6,10 +6,10 @@ metadata:
 certificates:
 
 settings:
-  kubeContext:  
+  kubeContext:
 
 namespaces:
-  staging: "staging" 
+  staging: "staging"
   production: "default"
 
 helmRepos:

--- a/utils.go
+++ b/utils.go
@@ -146,30 +146,6 @@ func readFile(filepath string) string {
 	return string(data)
 }
 
-// printHelp prints Helmsman commands
-func printHelp() {
-	fmt.Println("Helmsman version: " + appVersion)
-	fmt.Println("Helmsman is a Helm Charts as Code tool which allows you to automate the deployment/management of your Helm charts.")
-	fmt.Println("Usage: helmsman [options]")
-	fmt.Println()
-	fmt.Println("Options:")
-	fmt.Println("-f                        desired state file name(s), may be supplied more than once to merge state files.")
-	fmt.Println("-e                        file(s) to load environment variables from (default .env), may be supplied more than once")
-	fmt.Println("--debug                   prints basic logs during execution.")
-	fmt.Println("--dry-run                 apply the dry-run option for helm commands.")
-	fmt.Println("--apply                   generates and applies an action plan.")
-	fmt.Println("--verbose                 prints more verbose logs during execution.")
-	fmt.Println("--ns-override             overrides defined namespaces with a provided one.")
-	fmt.Println("--skip-validation         generates and applies an action plan.")
-	fmt.Println("--apply-labels            applies Helmsman labels to Helm state for all defined apps.")
-	fmt.Println("--keep-untracked-releases keep releases that are managed by Helmsman and are no longer tracked in your desired state.")
-	fmt.Println("--help                    prints Helmsman help.")
-	fmt.Println("--no-banner               don't show the banner")
-	fmt.Println("--no-color                don't use colors")
-	fmt.Println("--no-fancy                don't show the banner and don't use colors")
-	fmt.Println("-v                        prints Helmsman version.")
-}
-
 // logVersions prints the versions of kubectl and helm to the logs
 func logVersions() {
 	log.Println("VERBOSE: kubectl client version: " + kubectlVersion)

--- a/utils.go
+++ b/utils.go
@@ -19,7 +19,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/Praqma/helmsman/aws"
 	"github.com/Praqma/helmsman/gcs"
-	"github.com/logrusorgru/aurora"
 )
 
 // printMap prints to the console any map of string keys and values.
@@ -166,6 +165,8 @@ func printHelp() {
 	fmt.Println("--keep-untracked-releases keep releases that are managed by Helmsman and are no longer tracked in your desired state.")
 	fmt.Println("--help                    prints Helmsman help.")
 	fmt.Println("--no-banner               don't show the banner")
+	fmt.Println("--no-color                don't use colors")
+	fmt.Println("--no-fancy                don't show the banner and don't use colors")
 	fmt.Println("-v                        prints Helmsman version.")
 }
 
@@ -302,7 +303,7 @@ func logError(msg string) {
 	if _, err := url.ParseRequestURI(s.Settings.SlackWebhook); err == nil {
 		notifySlack(msg, s.Settings.SlackWebhook, true, apply)
 	}
-	log.Fatal(aurora.Bold(aurora.Red(msg)))
+	log.Fatal(style.Bold(style.Red(msg)))
 }
 
 // getBucketElements returns a map containing the bucket name and the file path inside the bucket


### PR DESCRIPTION
added two new flags, `--no-color` disables the colorful output and `--no-fancy` disables both the colorful output and the banner.

The diff printed by `helm diff` is still printed in color but that's because of https://github.com/databus23/helm-diff/issues/98

This is important because some CI tools don't support colorful outputs out of the box.