### PR TITLE
Adding some quotes

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -225,7 +225,7 @@ func diffRelease(r *release) string {
 
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", "helm diff " + colorFlag + "upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + r.Version + " " + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r)},
+		Args:        []string{"-c", "helm diff " + colorFlag + "upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + " " + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r)},
 		Description: "upgrading release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -203,7 +203,7 @@ func validateReleaseCharts(apps map[string]*release) (bool, string) {
 	for app, r := range apps {
 		cmd := command{
 			Cmd:         "bash",
-			Args:        []string{"-c", "helm search " + r.Chart + " --version " + r.Version + " -l"},
+			Args:        []string{"-c", "helm search " + r.Chart + " --version " + strconv.Quote(r.Version) + " -l"},
 			Description: "validating if chart " + r.Chart + "-" + r.Version + " is available in the defined repos.",
 		}
 
@@ -256,7 +256,7 @@ func addHelmRepos(repos map[string]string) (bool, string) {
 		}
 		cmd := command{
 			Cmd:         "bash",
-			Args:        []string{"-c", "helm repo add " + repoName + " " + url},
+			Args:        []string{"-c", "helm repo add " + repoName + " " + strconv.Quote(url)},
 			Description: "adding repo " + repoName,
 		}
 

--- a/kube_helpers.go
+++ b/kube_helpers.go
@@ -81,7 +81,7 @@ func createNamespace(ns string) {
 	}
 
 	if exitCode, _ := cmd.exec(debug, verbose); exitCode != 0 {
-		log.Println("WARN: I could not create namespace [" +
+		log.Println("WARN: I could not create namespace [ " +
 			ns + " ]. It already exists. I am skipping this.")
 	}
 }


### PR DESCRIPTION
Adding quotes to Helm repo URL and Helm chart version.

This solves #94 and maybe #78 

This is the previous verbose output:
```
2018/09/27 20:49:59 VERBOSE: helm repo add stable https://kubernetes-charts.storage.googleapis.com
2018/09/27 20:50:00 VERBOSE: helm repo add incubator http://storage.googleapis.com/kubernetes-charts-incubator
2018/09/27 20:50:01 VERBOSE: helm repo add coreos https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/
```

This is the new verbose output, you can see the quotes there:
```
2018/09/27 20:50:25 VERBOSE: helm repo add coreos "https://s3-eu-west-1.amazonaws.com/coreos-charts/stable/"
2018/09/27 20:50:25 VERBOSE: helm repo add stable "https://kubernetes-charts.storage.googleapis.com"
2018/09/27 20:50:26 VERBOSE: helm repo add incubator "http://storage.googleapis.com/kubernetes-charts-incubator"
```

Also added quotes for chart version:
```
2018/09/27 20:50:27 VERBOSE: helm search test-incubator/test-content --version "0.1.1" -l
2018/09/27 20:50:28 VERBOSE: helm search test-incubator/test-foo --version "0.1.2" -l
```