### PR TITLE
Adding to Install section for helmsman

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ To run a dry-run:
 
 ## From binary
 
+Please make sure the following are installed prior to using `helmsman`:
+
+- [kubectl](https://github.com/kubernetes/kubectl)
+- [helm](https://github.com/helm/helm)
+- [helm-diff](https://github.com/databus23/helm-diff) (`helmsman` >= 1.6.0)
+
+
 Check the [releases page](https://github.com/Praqma/Helmsman/releases) for the different versions.
 ```
 # on Linux


### PR DESCRIPTION
I would like to propose adding ~a `prereqs`~ to the install section in the README.md

Initially I was unaware that I needed more than just `kubectl` and `helm` to use `helmsman`. But it looks like `helmsman` requires the helm diff plugin:

```sh
helm $ helmsman -debug -f helmsman.yaml
 _          _
| |        | |
| |__   ___| |_ __ ___  ___ _ __ ___   __ _ _ __
| '_ \ / _ \ | '_ ` _ \/ __| '_ ` _ \ / _` | '_ \
| | | |  __/ | | | | | \__ \ | | | | | (_| | | | |
|_| |_|\___|_|_| |_| |_|___/_| |_| |_|\__,_|_| |_| version: v1.6.2                             
A Helm-Charts-as-Code tool.


2018/10/01 20:08:12 INFO: checking Helm version
2018/10/01 20:08:12 INFO: checking kubectl version
2018/10/01 20:08:12 INFO: validating that kubectl is installed.
2018/10/01 20:08:13 INFO: validating that helm is installed.
2018/10/01 20:08:13 INFO: validating that diff is installed.
2018/10/01 20:08:13 ERROR: helm diff plugin is not installed/configured correctly. Aborting!
```

I think having ~a general `prereqs` section~ install dependencies would save new users time and provide a way to communicate additional dependencies if there end up being any in the future.

Relates to change made in https://github.com/Praqma/helmsman/pull/74