### PR TITLE
Fixes diff error when wait flag is set.

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -225,8 +225,8 @@ func diffRelease(r *release) string {
 
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", "helm diff " + colorFlag + "upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + " " + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r)},
-		Description: "upgrading release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
+		Args:        []string{"-c", "helm diff " + colorFlag + "upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + " " + getSetValues(r) + getSetStringValues(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r)},
+		Description: "diffing release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 
 	if exitCode, msg = cmd.exec(debug, verbose); exitCode != 0 {


### PR DESCRIPTION
The diff plugin errors if you pass the --wait flag, and I don't think --wait could mean anything in this context, so I removed it from the invocation.

I also updated the description of the command run by diffRelease so that it reflects what the command is doing.