### PR TITLE
Resolve values and secrets relative to dsf

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -307,13 +307,9 @@ func getValuesFiles(r *release) string {
 	var fileList []string
 
 	if r.ValuesFile != "" {
-		fileList = append(fileList, pwd+"/"+relativeDir+"/"+r.ValuesFile)
+		fileList = append(fileList,r.ValuesFile)
 	} else if len(r.ValuesFiles) > 0 {
-		tempValuesFiles := make([]string, len(r.ValuesFiles))
-		for i := 0; i < len(r.ValuesFiles); i++ {
-			tempValuesFiles[i] = pwd + "/" + relativeDir + "/" + r.ValuesFiles[i]
-		}
-		fileList = append(fileList, tempValuesFiles...)
+		fileList = append(fileList, r.ValuesFiles...)
 	}
 
 	if r.SecretsFile != "" {
@@ -323,13 +319,13 @@ func getValuesFiles(r *release) string {
 		if ok := decryptSecret(r.SecretsFile); !ok {
 			logError("Failed to decrypt secret file" + r.SecretsFile)
 		}
-		fileList = append(fileList, pwd+"/"+relativeDir+"/"+r.SecretsFile+".dec")
+		fileList = append(fileList, r.SecretsFile+".dec")
 	} else if len(r.SecretsFiles) > 0 {
 		if !helmPluginExists("secrets") {
 			logError("ERROR: helm secrets plugin is not installed/configured correctly. Aborting!")
 		}
 		for i := 0; i < len(r.SecretsFiles); i++ {
-			r.SecretsFiles[i] = pwd + "/" + relativeDir + "/" + r.SecretsFiles[i]
+			r.SecretsFiles[i] = r.SecretsFiles[i]
 			if ok := decryptSecret(r.SecretsFiles[i]); !ok {
 				logError("Failed to decrypt secret file" + r.SecretsFiles[i])
 			}

--- a/decision_maker_test.go
+++ b/decision_maker_test.go
@@ -29,7 +29,7 @@ func Test_getValuesFiles(t *testing.T) {
 				},
 				//s: st,
 			},
-			want: " -f " + pwd + "/" + relativeDir + "/test_files/values.yaml",
+			want: " -f test_files/values.yaml",
 		},
 		{
 			name: "test case 2",
@@ -47,7 +47,7 @@ func Test_getValuesFiles(t *testing.T) {
 				},
 				//s: st,
 			},
-			want: " -f " + pwd + "/" + relativeDir + "/test_files/values.yaml",
+			want: " -f test_files/values.yaml",
 		},
 		{
 			name: "test case 1",
@@ -65,7 +65,7 @@ func Test_getValuesFiles(t *testing.T) {
 				},
 				//s: st,
 			},
-			want: " -f " + pwd + "/" + relativeDir + "/test_files/values.yaml -f " + pwd + "/" + relativeDir + "/test_files/values2.yaml",
+			want: " -f test_files/values.yaml -f test_files/values2.yaml",
 		},
 	}
 	for _, tt := range tests {

--- a/init.go
+++ b/init.go
@@ -89,17 +89,6 @@ func init() {
 		os.Exit(0)
 	}
 
-	// initializing pwd and relative directory for DSF(s) and values files
-	pwd, _ = os.Getwd()
-	lastSlashIndex := -1
-	if len(files) > 0 {
-		lastSlashIndex = strings.LastIndex(files[0], "/")
-	}
-	relativeDir = "."
-	if lastSlashIndex != -1 {
-		relativeDir = files[0][:lastSlashIndex]
-	}
-
 	if v {
 		fmt.Println("Helmsman version: " + appVersion)
 		os.Exit(0)

--- a/main.go
+++ b/main.go
@@ -35,8 +35,6 @@ var keepUntrackedReleases bool
 var appVersion = "v1.6.3"
 var helmVersion string
 var kubectlVersion string
-var pwd string
-var relativeDir string
 var dryRun bool
 var destroy bool
 var showDiff bool

--- a/release_test.go
+++ b/release_test.go
@@ -252,7 +252,7 @@ func Test_validateRelease(t *testing.T) {
 					Enabled:     true,
 					Chart:       "repo/chartX",
 					Version:     "1.0",
-					ValuesFiles: []string{"./test_files/values.yaml", "./test_files/values2.yaml"},
+					ValuesFiles: []string{"./test_files/values.yaml", "test_files/values2.yaml"},
 					Purge:       true,
 					Test:        true,
 				},

--- a/release_test.go
+++ b/release_test.go
@@ -60,7 +60,7 @@ func Test_validateRelease(t *testing.T) {
 				s: st,
 			},
 			want:  false,
-			want1: "valuesFile must be a valid relative (from your first dsf file) file path for a yaml file, Or can be left empty.",
+			want1: "valuesFile must be a valid relative (from dsf file) file path for a yaml file, or can be left empty (provided path resolved to \"xyz.yaml\").",
 		}, {
 			name: "test case 3",
 			args: args{
@@ -78,7 +78,7 @@ func Test_validateRelease(t *testing.T) {
 				s: st,
 			},
 			want:  false,
-			want1: "valuesFile must be a valid relative (from your first dsf file) file path for a yaml file, Or can be left empty.",
+			want1: "valuesFile must be a valid relative (from dsf file) file path for a yaml file, or can be left empty (provided path resolved to \"test_files/values.xml\").",
 		}, {
 			name: "test case 4",
 			args: args{
@@ -241,7 +241,7 @@ func Test_validateRelease(t *testing.T) {
 				s: st,
 			},
 			want:  false,
-			want1: "the value for valuesFile 'xyz.yaml' must be a valid relative (from your first dsf file) file path for a yaml file.",
+			want1: "valuesFiles must be valid relative (from dsf file) file paths for a yaml file; path at index 0 provided path resolved to \"xyz.yaml\".",
 		}, {
 			name: "test case 13",
 			args: args{
@@ -252,7 +252,7 @@ func Test_validateRelease(t *testing.T) {
 					Enabled:     true,
 					Chart:       "repo/chartX",
 					Version:     "1.0",
-					ValuesFiles: []string{"test_files/values.yaml", "test_files/values2.yaml"},
+					ValuesFiles: []string{"./test_files/values.yaml", "./test_files/values2.yaml"},
 					Purge:       true,
 					Test:        true,
 				},


### PR DESCRIPTION
This is an alternative fix for #59. In this fix the relative paths are resolved when the DSF yaml/toml file is loaded, relative to the path that the dsf was loaded from. This aleviates the need to build paths based on pwd in multiple places, and makes it possible to have DSF files in different folders all merge together correctly.