### PR TITLE
Don't delete untracked releases on a dry-run

### DIFF
--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -438,7 +438,7 @@ func deleteUntrackedRelease(release string, tillerNamespace string) {
 	}
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", "helm delete --purge " + release + " --tiller-namespace " + tillerNamespace + tls},
+		Args:        []string{"-c", "helm delete --purge " + release + " --tiller-namespace " + tillerNamespace + tls + getDryRunFlags()},
 		Description: "deleting untracked release [ " + release + " ] from Tiller in namespace [[ " + tillerNamespace + " ]]",
 	}
 


### PR DESCRIPTION
There is a bug where untracked releases are really deleted even if you passed the --dry-run flag to helmsman. This fix ensures that the --dry-run flag is correctly passed along to helm when untracked releases are deleted. 