### PR TITLE
allow labeling namespaces

### DIFF
--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -131,6 +131,7 @@ Options:
 - **installTiller**: defines if Tiller should be deployed in this namespace or not. Default is false. Any chart desired to be deployed into a namespace with a Tiller deployed, will be deployed using that Tiller and not the one in kube-system unless you use the `TillerNamespace` option (see the [Apps](#apps) section below) to use another Tiller.
 > By default Tiller will be deployed into `kube-system` even if you don't define kube-system in the namespaces section. To prevent deploying Tiller into `kube-system, add kube-system in your namespaces section and set its installTiller to false.
 -**useTiller**: defines that you would like to use an existing Tiller from that namespace. Can't be set together with `installTiller`
+- **labels** : defines labels to be added to the namespace, doesn't remove existing labels but updates them if the label key exists with any other different value. You can define any key/value pairs. Default is empty.
 
 - **tillerServiceAccount**: defines what service account to use when deploying Tiller. If this is not set, the following options are considered:
 
@@ -166,6 +167,8 @@ tillerCert = "secrets/tiller.cert.pem"
 tillerKey = "$TILLER_KEY" # where TILLER_KEY=secrets/tiller.key.pem
 clientCert = "gs://mybucket/mydir/helm.cert.pem"
 clientKey = "s3://mybucket/mydir/helm.key.pem"
+[namespaces.production.labels]
+env = "prod"
 ```
 
 ```yaml
@@ -186,6 +189,8 @@ namespaces:
     tillerKey: "$TILLER_KEY" # where TILLER_KEY=secrets/tiller.key.pem
     clientCert: "gs://mybucket/mydir/helm.cert.pem"
     clientKey: "s3://mybucket/mydir/helm.key.pem"
+    labels:
+      env: "prod"
 ```
 
 ## Helm Repos

--- a/example.toml
+++ b/example.toml
@@ -43,6 +43,8 @@
 #    tillerKey = "secrets/tiller.key.pem"  # or GCS bucket gs://mybucket/tiller.key
 #    clientCert = "secrets/helm.cert.pem"
 #    clientKey = "secrets/helm.key.pem"
+    [namespaces.staging.labels]
+      env = "staging"
 
 
 # define any private/public helm charts repos you would like to get charts from

--- a/example.yaml
+++ b/example.yaml
@@ -37,6 +37,8 @@ namespaces:
     #tillerKey: "secrets/tiller.key.pem"  # or GCS bucket gs://mybucket/tiller.key
     #clientCert: "secrets/helm.cert.pem"
     #clientKey: "secrets/helm.key.pem"
+    labels:
+      env: "staging"
 
 
 # define any private/public helm charts repos you would like to get charts from

--- a/kube_helpers.go
+++ b/kube_helpers.go
@@ -55,8 +55,9 @@ func createRBAC(sa string, namespace string, sharedTiller bool) (bool, string) {
 // If --ns-override flag is used, it only creates the provided namespace in that flag
 func addNamespaces(namespaces map[string]namespace) {
 	if nsOverride == "" {
-		for ns := range namespaces {
-			createNamespace(ns)
+		for nsName, ns := range namespaces {
+			createNamespace(nsName)
+			labelNamespace(nsName, ns.Labels)
 		}
 	} else {
 		createNamespace(nsOverride)
@@ -83,6 +84,22 @@ func createNamespace(ns string) {
 	if exitCode, _ := cmd.exec(debug, verbose); exitCode != 0 {
 		log.Println("WARN: I could not create namespace [ " +
 			ns + " ]. It already exists. I am skipping this.")
+	}
+}
+
+// labelNamespace labels a namespace with provided labels
+func labelNamespace(ns string, labels map[string]string) {
+	for k, v := range labels {
+		cmd := command{
+			Cmd:         "bash",
+			Args:        []string{"-c", "kubectl label --overwrite namespace/" + ns + " " + k + "=" + v},
+			Description: "labeling namespace  " + ns,
+		}
+
+		if exitCode, _ := cmd.exec(debug, verbose); exitCode != 0 {
+			log.Println("WARN: I could not label namespace [ " + ns + " with " + k + "=" + v +
+				" ]. It already exists. I am skipping this.")
+		}
 	}
 }
 

--- a/release_test.go
+++ b/release_test.go
@@ -10,7 +10,7 @@ func Test_validateRelease(t *testing.T) {
 		Metadata:     make(map[string]string),
 		Certificates: make(map[string]string),
 		Settings:     (config{}),
-		Namespaces:   map[string]namespace{"namespace": namespace{false, false, false, "", "", "", "", "", ""}},
+		Namespaces:   map[string]namespace{"namespace": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)}},
 		HelmRepos:    make(map[string]string),
 		Apps:         make(map[string]*release),
 	}

--- a/state.go
+++ b/state.go
@@ -10,15 +10,16 @@ import (
 
 // namespace type represents the fields of a namespace
 type namespace struct {
-	Protected            bool   `yaml:"protected"`
-	InstallTiller        bool   `yaml:"installTiller"`
-	UseTiller            bool   `yaml:"useTiller"`
-	TillerServiceAccount string `yaml:"tillerServiceAccount"`
-	CaCert               string `yaml:"caCert"`
-	TillerCert           string `yaml:"tillerCert"`
-	TillerKey            string `yaml:"tillerKey"`
-	ClientCert           string `yaml:"clientCert"`
-	ClientKey            string `yaml:"clientKey"`
+	Protected            bool              `yaml:"protected"`
+	InstallTiller        bool              `yaml:"installTiller"`
+	UseTiller            bool              `yaml:"useTiller"`
+	TillerServiceAccount string            `yaml:"tillerServiceAccount"`
+	CaCert               string            `yaml:"caCert"`
+	TillerCert           string            `yaml:"tillerCert"`
+	TillerKey            string            `yaml:"tillerKey"`
+	ClientCert           string            `yaml:"clientCert"`
+	ClientKey            string            `yaml:"clientKey"`
+	Labels               map[string]string `yaml:"labels"`
 }
 
 // config type represents the settings fields

--- a/state_test.go
+++ b/state_test.go
@@ -34,7 +34,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https://192.168.99.100:8443",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -53,7 +53,7 @@ func Test_state_validate(t *testing.T) {
 				},
 				Settings: config{},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -77,7 +77,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https://192.168.99.100:8443",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -98,7 +98,7 @@ func Test_state_validate(t *testing.T) {
 					KubeContext: "minikube",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -122,7 +122,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https://192.168.99.100:8443",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -146,7 +146,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "$URI", // unset env
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -170,7 +170,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "$SET_URI", // set env var
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -194,7 +194,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https//192.168.99.100:8443", // invalid url
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -217,7 +217,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https://192.168.99.100:8443",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -238,7 +238,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https://192.168.99.100:8443",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -262,7 +262,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https://192.168.99.100:8443",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -280,7 +280,7 @@ func Test_state_validate(t *testing.T) {
 					KubeContext: "minikube",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -330,7 +330,7 @@ func Test_state_validate(t *testing.T) {
 					KubeContext: "minikube",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: nil,
 				Apps:      make(map[string]*release),
@@ -345,7 +345,7 @@ func Test_state_validate(t *testing.T) {
 					KubeContext: "minikube",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{},
 				Apps:      make(map[string]*release),
@@ -360,7 +360,7 @@ func Test_state_validate(t *testing.T) {
 					KubeContext: "minikube",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -378,7 +378,7 @@ func Test_state_validate(t *testing.T) {
 					KubeContext: "minikube",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", ""},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",


### PR DESCRIPTION
We are required to label namespaces to allow us to use NetworkPolicies. NetworkPolicies only works with namespace selectors and doesn't work with namespace names.