### PR TITLE
Override existing values when merging DSFs

### DIFF
--- a/release.go
+++ b/release.go
@@ -11,26 +11,26 @@ import (
 
 // release type representing Helm releases which are described in the desired state
 type release struct {
-	Name            string   `yaml:"name"`
-	Description     string   `yaml:"description"`
-	Namespace       string   `yaml:"namespace"`
-	Enabled         bool     `yaml:"enabled"`
-	Chart           string   `yaml:"chart"`
-	Version         string   `yaml:"version"`
-	ValuesFile      string   `yaml:"valuesFile"`
-	ValuesFiles     []string `yaml:"valuesFiles"`
-	SecretsFile     string   `yaml:"secretsFile"`
-	SecretsFiles    []string `yaml:"secretsFiles"`
-	Purge           bool     `yaml:"purge"`
-	Test            bool     `yaml:"test"`
-	Protected       bool     `yaml:"protected"`
-	Wait            bool     `yaml:"wait"`
-	Priority        int      `yaml:"priority"`
-	TillerNamespace string   `yaml:"tillerNamespace"`
-	Set             map[string]string
+	Name            string            `yaml:"name"`
+	Description     string            `yaml:"description"`
+	Namespace       string            `yaml:"namespace"`
+	Enabled         bool              `yaml:"enabled"`
+	Chart           string            `yaml:"chart"`
+	Version         string            `yaml:"version"`
+	ValuesFile      string            `yaml:"valuesFile"`
+	ValuesFiles     []string          `yaml:"valuesFiles"`
+	SecretsFile     string            `yaml:"secretsFile"`
+	SecretsFiles    []string          `yaml:"secretsFiles"`
+	Purge           bool              `yaml:"purge"`
+	Test            bool              `yaml:"test"`
+	Protected       bool              `yaml:"protected"`
+	Wait            bool              `yaml:"wait"`
+	Priority        int               `yaml:"priority"`
+	TillerNamespace string            `yaml:"tillerNamespace"`
+	Set             map[string]string `yaml:"set"`
 	SetString       map[string]string `yaml:"setString"`
 	NoHooks         bool              `yaml:"noHooks"`
-	Timeout         int
+	Timeout         int               `yaml:"timeout"`
 }
 
 // validateRelease validates if a release inside a desired state meets the specifications or not.
@@ -155,6 +155,6 @@ func (r release) print() {
 	fmt.Println("\tno-hooks : ", r.NoHooks)
 	fmt.Println("\ttimeout : ", r.Timeout)
 	fmt.Println("\tvalues to override from env:")
-	printMap(r.Set)
+	printMap(r.Set, 2)
 	fmt.Println("------------------- ")
 }

--- a/state.go
+++ b/state.go
@@ -212,10 +212,10 @@ func (s state) print() {
 
 	fmt.Println("\nMetadata: ")
 	fmt.Println("--------- ")
-	printMap(s.Metadata)
+	printMap(s.Metadata, 0)
 	fmt.Println("\nCertificates: ")
 	fmt.Println("--------- ")
-	printMap(s.Certificates)
+	printMap(s.Certificates, 0)
 	fmt.Println("\nSettings: ")
 	fmt.Println("--------- ")
 	fmt.Printf("%+v\n", s.Settings)
@@ -224,7 +224,7 @@ func (s state) print() {
 	printNamespacesMap(s.Namespaces)
 	fmt.Println("\nRepositories: ")
 	fmt.Println("------------- ")
-	printMap(s.HelmRepos)
+	printMap(s.HelmRepos, 0)
 	fmt.Println("\nApplications: ")
 	fmt.Println("--------------- ")
 	for _, r := range s.Apps {

--- a/utils.go
+++ b/utils.go
@@ -21,9 +21,9 @@ import (
 )
 
 // printMap prints to the console any map of string keys and values.
-func printMap(m map[string]string) {
+func printMap(m map[string]string, indent int) {
 	for key, value := range m {
-		fmt.Println(key, " : ", value)
+		fmt.Println(strings.Repeat("\t", indent)+key, " : ", value)
 	}
 }
 


### PR DESCRIPTION
Hi,

As a user, when passing multiple DSFs with the `-f` option I expect the values I override in the latter files to be overwritten in the final state, like when passing multiple compose files to `docker-compose`.

This PR addresses that.