### PR TITLE
Breaking: Expanding envs on the whole dfs file.

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -307,7 +307,7 @@ func getValuesFiles(r *release) string {
 	var fileList []string
 
 	if r.ValuesFile != "" {
-		fileList = append(fileList,r.ValuesFile)
+		fileList = append(fileList, r.ValuesFile)
 	} else if len(r.ValuesFiles) > 0 {
 		fileList = append(fileList, r.ValuesFiles...)
 	}
@@ -344,8 +344,7 @@ func getValuesFiles(r *release) string {
 func getSetValues(r *release) string {
 	result := ""
 	for k, v := range r.Set {
-		value := substituteEnv(v)
-		result = result + " --set " + k + "=\"" + strings.Replace(value, ",", "\\,", -1) + "\""
+		result = result + " --set " + k + "=\"" + strings.Replace(v, ",", "\\,", -1) + "\""
 	}
 	return result
 }
@@ -354,8 +353,7 @@ func getSetValues(r *release) string {
 func getSetStringValues(r *release) string {
 	result := ""
 	for k, v := range r.SetString {
-		value := substituteEnv(v)
-		result = result + " --set-string " + k + "=\"" + strings.Replace(value, ",", "\\,", -1) + "\""
+		result = result + " --set-string " + k + "=\"" + strings.Replace(v, ",", "\\,", -1) + "\""
 	}
 	return result
 }

--- a/release.go
+++ b/release.go
@@ -66,7 +66,7 @@ func validateRelease(appLabel string, r *release, names map[string]map[string]bo
 	if r.Version == "" {
 		return false, "version can't be empty."
 	}
-	r.Version = substituteEnv(r.Version)
+	r.Version = r.Version
 
 	_, err := os.Stat(r.ValuesFile)
 	if r.ValuesFile != "" && (!isOfType(r.ValuesFile, ".yaml") || err != nil) {

--- a/state.go
+++ b/state.go
@@ -56,7 +56,6 @@ func (s state) validate() (bool, string) {
 			"kubeContext to use. Can't work without it. Sorry!"
 	} else if s.Settings.ClusterURI != "" {
 
-		s.Settings.ClusterURI = substituteEnv(s.Settings.ClusterURI)
 		if _, err := url.ParseRequestURI(s.Settings.ClusterURI); err != nil {
 			return false, "ERROR: settings validation failed -- clusterURI must have a valid URL set in an env variable or passed directly. Either the env var is missing/empty or the URL is invalid."
 		}
@@ -64,9 +63,7 @@ func (s state) validate() (bool, string) {
 		if s.Settings.Username == "" {
 			return false, "ERROR: settings validation failed -- username must be provided if clusterURI is defined."
 		}
-		if s.Settings.Password != "" {
-			s.Settings.Password = substituteEnv(s.Settings.Password)
-		} else {
+		if s.Settings.Password == "" {
 			return false, "ERROR: settings validation failed -- password must be provided if clusterURI is defined."
 		}
 
@@ -77,7 +74,6 @@ func (s state) validate() (bool, string) {
 
 	// slack webhook validation (if provided)
 	if s.Settings.SlackWebhook != "" {
-		s.Settings.SlackWebhook = substituteEnv(s.Settings.SlackWebhook)
 		if _, err := url.ParseRequestURI(s.Settings.SlackWebhook); err != nil {
 			return false, "ERROR: settings validation failed -- slackWebhook must be a valid URL."
 		}
@@ -187,13 +183,12 @@ func (s state) validate() (bool, string) {
 
 // isValidCert checks if a certificate/key path/URI is valid
 func isValidCert(value string) (bool, string) {
-	tmp := substituteEnv(value)
-	_, err1 := url.ParseRequestURI(tmp)
-	_, err2 := os.Stat(tmp)
-	if err2 != nil && (err1 != nil || (!strings.HasPrefix(tmp, "s3://") && !strings.HasPrefix(tmp, "gs://"))) {
+	_, err1 := url.ParseRequestURI(value)
+	_, err2 := os.Stat(value)
+	if err2 != nil && (err1 != nil || (!strings.HasPrefix(value, "s3://") && !strings.HasPrefix(value, "gs://"))) {
 		return false, ""
 	}
-	return true, tmp
+	return true, value
 }
 
 // tillerTLSEnabled checks if Tiller is desired to be deployed with TLS enabled for a given namespace

--- a/utils.go
+++ b/utils.go
@@ -37,7 +37,12 @@ func printNamespacesMap(m map[string]namespace) {
 // fromTOML reads a toml file and decodes it to a state type.
 // It uses the BurntSuchi TOML parser which throws an error if the TOML file is not valid.
 func fromTOML(file string, s *state) (bool, string) {
-	if _, err := toml.DecodeFile(file, s); err != nil {
+	rawTomlFile, err := ioutil.ReadFile(file)
+	if err != nil {
+		return false, err.Error()
+	}
+	tomlFile := substituteEnv(string(rawTomlFile))
+	if _, err := toml.Decode(tomlFile, s); err != nil {
 		return false, err.Error()
 	}
 
@@ -75,10 +80,11 @@ func toTOML(file string, s *state) {
 // fromYAML reads a yaml file and decodes it to a state type.
 // parser which throws an error if the YAML file is not valid.
 func fromYAML(file string, s *state) (bool, string) {
-	yamlFile, err := ioutil.ReadFile(file)
+	rawYamlFile, err := ioutil.ReadFile(file)
 	if err != nil {
 		return false, err.Error()
 	}
+	yamlFile := []byte(substituteEnv(string(rawYamlFile)))
 	if err = yaml.Unmarshal(yamlFile, s); err != nil {
 		return false, err.Error()
 	}
@@ -175,12 +181,18 @@ func logVersions() {
 	log.Println("VERBOSE: Helm client version: " + helmVersion)
 }
 
+// add $$ escaping for $ strings
+func expandEnv(s string) string {
+	os.Setenv("HELMSMAN_DOLLAR", "$")
+	return os.ExpandEnv(strings.Replace(s, "$$", "${HELMSMAN_DOLLAR}", -1))
+}
+
 // substituteEnv checks if a string has an env variable (contains '$'), then it returns its value
 // if the env variable is empty or unset, an empty string is returned
 // if the string does not contain '$', it is returned as is.
 func substituteEnv(name string) string {
 	if strings.Contains(name, "$") {
-		return os.ExpandEnv(name)
+		return expandEnv(name)
 	}
 	return name
 }


### PR DESCRIPTION
This patch brings a global dfs file environment variable expansion. For
escaping "$" characters one needs to use "$$".

This change may impact some users with dfs files including "$" strings.