### PR TITLE
Fix helm diff execution failure when timeout is set for an app

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -225,7 +225,7 @@ func diffRelease(r *release) string {
 
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", "helm diff " + colorFlag + "upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + " " + getSetValues(r) + getSetStringValues(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r)},
+		Args:        []string{"-c", "helm diff " + colorFlag + "upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + " " + getSetValues(r) + getSetStringValues(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getNoHooks(r)},
 		Description: "diffing release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 


### PR DESCRIPTION
This fixes execution failures of the `helm diff` subcommand when an app has been defined in the Helmsman state with the `timeout` argument.

Take the example app:
```
[apps]
  [apps.grafana]
    name = "grafana"
    enabled = true
    chart = "stable/grafana"
    version = "1.17.4"
    timeout = 60
    wait = true
```

When running `helmsman --show-diff` for the state file, Helmsman will return the following error when trying to run a diff for this app
```
2018/11/19 15:16:36 VERBOSE: helm search stable/grafana --version "1.17.4" -l
2018/11/19 15:16:37 INFO: checking what I need to do for your charts ...
2018/11/19 15:16:37 INFO: mapping the current helm state ...
2018/11/19 15:16:37 VERBOSE: helm list --all --max 0 --output json --tiller-namespace default
2018/11/19 15:16:37 VERBOSE: helm list --all --max 0 --output json --tiller-namespace kube-system
2018/11/19 15:16:38 VERBOSE: helm diff upgrade grafana stable/grafana --version "1.17.4"  --tiller-namespace kube-system --timeout 60
2018/11/19 15:14:26 INFO: checking what I need to do for your charts ...
2018/11/19 15:14:26 INFO: mapping the current helm state ...
2018/11/19 15:14:27 Command returned with exit code: . And error message: Error: unknown flag: --timeout
Usage:
  diff upgrade [flags] [RELEASE] [CHART]

Examples:
  helm diff upgrade my-release stable/postgresql --values values.yaml

Flags:
      --allow-unreleased         enables diffing of releases that are not yet deployed via Helm
  -C, --context int              output NUM lines of context around changes (default -1)
      --detailed-exitcode        return a non-zero exit code when there are changes
      --devel                    use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored.
  -h, --help                     help for upgrade
      --home string              location of your Helm config. Overrides $HELM_HOME (default "/Users/shaun.mansell/.helm")
      --namespace string         namespace to assume the release to be installed into (default "default")
      --reset-values             reset the values to the ones built into the chart and merge in any new values
      --reuse-values             reuse the last release's values and merge in any new values
      --set stringArray          set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
      --set-file stringArray     set values from respective files specified via the command line (can specify multiple or separate values with commas: key1=path1,key2=path2)
      --set-string stringArray   set STRING values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
      --suppress stringArray     allows suppression of the values listed in the diff output
  -q, --suppress-secrets         suppress secrets in the output
      --tls                      enable TLS for request
      --tls-ca-cert string       path to TLS CA certificate file (default "$HELM_HOME/ca.pem")
      --tls-cert string          path to TLS certificate file (default "$HELM_HOME/cert.pem")
      --tls-key string           path to TLS key file (default "$HELM_HOME/key.pem")
      --tls-verify               enable TLS for request and verify remote
  -f, --values valueFiles        specify values in a YAML file (can specify multiple) (default [])
      --version string           specify the exact chart version to use. If this is not specified, the latest version is used

Global Flags:
      --no-color   remove colors from the output

Error: plugin "diff" exited with error
```