### PR TITLE
feat: Support local charts on file system

### DIFF
--- a/docs/how_to/use_local_charts.md
+++ b/docs/how_to/use_local_charts.md
@@ -4,7 +4,11 @@ version: v1.3.0-rc
 
 # use local helm charts
 
-You can use your locally developed charts. But first, you have to serve them on localhost using helm's `serve` option.
+You can use your locally developed charts. 
+
+## Served by Helm
+
+You can serve them on localhost using helm's `serve` option.
 
 ```toml
 ...
@@ -29,3 +33,10 @@ helmRepos:
 ...
 
 ```
+
+## From file system
+
+If you use a file path (relative to the DSF, or absolute) for the ```chart``` attribute
+helmsman will try to resolve that chart from the local file system. The chart on the 
+local file system must have a version matching the version specified in the DSF.
+

--- a/release.go
+++ b/release.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	version "github.com/hashicorp/go-version"
+	"github.com/hashicorp/go-version"
 )
 
 // release type representing Helm releases which are described in the desired state


### PR DESCRIPTION
This adds support for charts that are on the file system rather than in a repo. It works by checking
whether a chart has a repo that's listed in the repos section of the DSF. If it doesn't, the chart
name is treated as a file path instead. If the chart is not present on the file system, or the chart
on the file system is a different version than specified in the DSF, validation fails.

This fixes #51.