### PR TITLE
Add colors to decision outputs

### DIFF
--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -426,7 +426,7 @@ func cleanUntrackedReleases() {
 	} else {
 		for ns, releases := range toDelete {
 			for r := range releases {
-				logDecision("DECISION: untracked release found: release [ "+r+" ] from Tiller in namespace [ "+ns+" ]. It will be deleted.", -800)
+				logDecision("DECISION: untracked release found: release [ "+r+" ] from Tiller in namespace [ "+ns+" ]. It will be deleted.", -800, delete)
 				deleteUntrackedRelease(r, ns)
 			}
 		}

--- a/plan.go
+++ b/plan.go
@@ -8,12 +8,32 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/logrusorgru/aurora"
 )
+
+// decisionType type representing type of Decision for console output
+type decisionType int
+
+const (
+	create decisionType = iota + 1
+	change
+	delete
+	noop
+)
+
+var decisionColor = map[decisionType]aurora.Color{
+	create: aurora.BlueFg,
+	change: aurora.BrownFg,
+	delete: aurora.RedFg,
+	noop:   aurora.GreenFg,
+}
 
 // orderedDecision type representing a Decision and it's priority weight
 type orderedDecision struct {
 	Description string
 	Priority    int
+	Type        decisionType
 }
 
 // orderedCommand type representing a Command and it's priority weight and the targeted release from the desired state
@@ -53,10 +73,11 @@ func (p *plan) addCommand(cmd command, priority int, r *release) {
 }
 
 // addDecision adds a decision type to the plan
-func (p *plan) addDecision(decision string, priority int) {
+func (p *plan) addDecision(decision string, priority int, decisionType decisionType) {
 	od := orderedDecision{
 		Description: decision,
 		Priority:    priority,
+		Type:        decisionType,
 	}
 	p.Decisions = append(p.Decisions, od)
 }
@@ -98,7 +119,7 @@ func (p plan) printPlan() {
 	fmt.Println("----------------------")
 	log.Println(style.Bold(style.Green("INFO: Plan generated at: " + p.Created.Format("Mon Jan _2 2006 15:04:05"))))
 	for _, decision := range p.Decisions {
-		fmt.Println(style.Green(decision.Description + " -- priority: " + strconv.Itoa(decision.Priority)))
+		fmt.Println(style.Colorize(decision.Description+" -- priority: "+strconv.Itoa(decision.Priority), decisionColor[decision.Type]))
 	}
 }
 

--- a/plan_test.go
+++ b/plan_test.go
@@ -104,7 +104,7 @@ func Test_plan_addDecision(t *testing.T) {
 				Decisions: tt.fields.Decisions,
 				Created:   tt.fields.Created,
 			}
-			p.addDecision(tt.args.decision, 0)
+			p.addDecision(tt.args.decision, 0, noop)
 			if got := len(p.Decisions); got != 1 {
 				t.Errorf("addDecision(): got  %v, want 1", got)
 			}


### PR DESCRIPTION
Currently all changes are displayed as wall of green text. So sometimes its easy to miss a change when there are a lot of addons. This PR adds colours to changes for visibility. Red for deleting, Blue for adding new addon, Yellow/Orange for change, Green for no change.

Before:
<img width="1011" alt="screenshot 2018-12-14 at 19 46 58" src="https://user-images.githubusercontent.com/9439689/50084610-3a20e280-0200-11e9-8e59-287dbdb3e452.png">

After:
<img width="1009" alt="screenshot 2018-12-14 at 19 47 09" src="https://user-images.githubusercontent.com/9439689/50084631-49079500-0200-11e9-9a18-fc7c67d3db77.png">
