### PR TITLE
added poc way of supporting tillerless helm via the tiller plugin

### DIFF
--- a/command.go
+++ b/command.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -42,6 +43,10 @@ func (c command) exec(debug bool, verbose bool) (int, string) {
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+
+	// we need to tell the TILLER to be silent. This will only matter in
+	// tillerless mode.
+	cmd.Env = append(os.Environ(), "HELM_TILLER_SILENT=true")
 
 	if err := cmd.Start(); err != nil {
 		logError("ERROR: cmd.Start: " + err.Error())

--- a/decision_maker.go
+++ b/decision_maker.go
@@ -29,7 +29,7 @@ func makePlan(s *state) *plan {
 func decide(r *release, s *state) {
 	if destroy {
 		if ok, rs := helmReleaseExists(r, ""); ok {
-			deleteRelease(r, rs, s)
+			deleteRelease(r, rs)
 			return
 		}
 	}
@@ -40,7 +40,7 @@ func decide(r *release, s *state) {
 			if !isProtected(r, rs) {
 
 				// delete it
-				deleteRelease(r, rs, s)
+				deleteRelease(r, rs)
 
 			} else {
 				logDecision("DECISION: release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is PROTECTED. Operations are not allowed on this release until "+
@@ -53,7 +53,7 @@ func decide(r *release, s *state) {
 	} else { // check for install/upgrade/rollback
 		if ok, rs := helmReleaseExists(r, "deployed"); ok {
 			if !isProtected(r, rs) {
-				inspectUpgradeScenario(r, rs, s) // upgrade or move
+				inspectUpgradeScenario(r, rs) // upgrade or move
 
 			} else {
 				logDecision("DECISION: release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is PROTECTED. Operations are not allowed on this release until "+
@@ -63,7 +63,7 @@ func decide(r *release, s *state) {
 		} else if ok, rs := helmReleaseExists(r, "deleted"); ok {
 			if !isProtected(r, rs) {
 
-				rollbackRelease(r, rs, s) // rollback
+				rollbackRelease(r, rs) // rollback
 
 			} else {
 				logDecision("DECISION: release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is PROTECTED. Operations are not allowed on this release until "+
@@ -75,7 +75,7 @@ func decide(r *release, s *state) {
 			if !isProtected(r, rs) {
 
 				logDecision("DECISION: release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is in FAILED state. I will upgrade it for you. Hope it gets fixed!", r.Priority, change)
-				upgradeRelease(r, s)
+				upgradeRelease(r)
 
 			} else {
 				logDecision("DECISION: release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is PROTECTED. Operations are not allowed on this release until "+
@@ -83,7 +83,7 @@ func decide(r *release, s *state) {
 			}
 		} else {
 
-			installRelease(r, s) // install a new release
+			installRelease(r) // install a new release
 
 		}
 
@@ -95,8 +95,8 @@ func decide(r *release, s *state) {
 // operate without a tiller it will return `helm tiller run NAMESPACE -- helm`
 // where NAMESPACE is the namespace that the release is configured to use.
 // If not configured to run without a tiller will just return `helm`.
-func helmCommand(namespace string, tillerless bool) string {
-	if tillerless {
+func helmCommand(namespace string) string {
+	if settings.Tillerless {
 		return "helm tiller run " + namespace + " -- helm"
 	}
 
@@ -105,15 +105,15 @@ func helmCommand(namespace string, tillerless bool) string {
 
 // helmCommandFromConfig calls helmCommand returning the correct way to invoke
 // helm.
-func helmCommandFromConfig(r *release, s *state) string {
-	return helmCommand(getDesiredTillerNamespace(r), s.Settings.Tillerless)
+func helmCommandFromConfig(r *release) string {
+	return helmCommand(getDesiredTillerNamespace(r))
 }
 
 // testRelease creates a Helm command to test a particular release.
-func testRelease(r *release, s *state) {
+func testRelease(r *release) {
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", helmCommandFromConfig(r, s) + " test " + r.Name + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r)},
+		Args:        []string{"-c", helmCommandFromConfig(r) + " test " + r.Name + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r)},
 		Description: "running tests for release [ " + r.Name + " ]",
 	}
 	outcome.addCommand(cmd, r.Priority, r)
@@ -122,11 +122,11 @@ func testRelease(r *release, s *state) {
 }
 
 // installRelease creates a Helm command to install a particular release in a particular namespace using a particular Tiller.
-func installRelease(r *release, s *state) {
+func installRelease(r *release) {
 
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", helmCommandFromConfig(r, s) + " install " + r.Chart + " -n " + r.Name + " --namespace " + r.Namespace + getValuesFiles(r) + " --version " + r.Version + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r) + getDryRunFlags()},
+		Args:        []string{"-c", helmCommandFromConfig(r) + " install " + r.Chart + " -n " + r.Name + " --namespace " + r.Namespace + getValuesFiles(r) + " --version " + r.Version + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r) + getDryRunFlags()},
 		Description: "installing release [ " + r.Name + " ] in namespace [[ " + r.Namespace + " ]] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 	outcome.addCommand(cmd, r.Priority, r)
@@ -134,30 +134,30 @@ func installRelease(r *release, s *state) {
 		r.Namespace+" ]] using Tiller in [ "+getDesiredTillerNamespace(r)+" ]", r.Priority, create)
 
 	if r.Test {
-		testRelease(r, s)
+		testRelease(r)
 	}
 }
 
 // rollbackRelease evaluates if a rollback action needs to be taken for a given release.
 // if the release is already deleted but from a different namespace than the one specified in input,
 // it purge deletes it and create it in the specified namespace.
-func rollbackRelease(r *release, rs releaseState, s *state) {
+func rollbackRelease(r *release, rs releaseState) {
 
 	if r.Namespace == rs.Namespace {
 
 		cmd := command{
 			Cmd:         "bash",
-			Args:        []string{"-c", helmCommandFromConfig(r, s) + " rollback " + r.Name + " " + getReleaseRevision(rs) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r) + getDryRunFlags()},
+			Args:        []string{"-c", helmCommandFromConfig(r) + " rollback " + r.Name + " " + getReleaseRevision(rs) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r) + getDryRunFlags()},
 			Description: "rolling back release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 		}
 		outcome.addCommand(cmd, r.Priority, r)
-		upgradeRelease(r, s) // this is to reflect any changes in values file(s)
+		upgradeRelease(r) // this is to reflect any changes in values file(s)
 		logDecision("DECISION: release [ "+r.Name+" ] is currently deleted and is desired to be rolledback to "+
 			"namespace [[ "+r.Namespace+" ]] . It will also be upgraded in case values have changed.", r.Priority, change)
 
 	} else {
 
-		reInstallRelease(r, rs, s)
+		reInstallRelease(r, rs)
 		logDecision("DECISION: release [ "+r.Name+" ] is deleted BUT from namespace [[ "+rs.Namespace+
 			" ]]. Will purge delete it from there and install it in namespace [[ "+r.Namespace+" ]]", r.Priority, change)
 		logDecision("WARNING: rolling back release [ "+r.Name+" ] from [[ "+rs.Namespace+" ]] to [[ "+r.Namespace+
@@ -168,7 +168,7 @@ func rollbackRelease(r *release, rs releaseState, s *state) {
 }
 
 // deleteRelease deletes a release from a particular Tiller in a k8s cluster
-func deleteRelease(r *release, rs releaseState, s *state) {
+func deleteRelease(r *release, rs releaseState) {
 	p := ""
 	purgeDesc := ""
 	if r.Purge {
@@ -183,7 +183,7 @@ func deleteRelease(r *release, rs releaseState, s *state) {
 
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", helmCommandFromConfig(r, s) + " delete " + p + " " + r.Name + getCurrentTillerNamespaceFlag(rs) + getTLSFlags(r) + getDryRunFlags()},
+		Args:        []string{"-c", helmCommandFromConfig(r) + " delete " + p + " " + r.Name + getCurrentTillerNamespaceFlag(rs) + getTLSFlags(r) + getDryRunFlags()},
 		Description: "deleting release [ " + r.Name + " ] from namespace [[ " + r.Namespace + " ]] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 	outcome.addCommand(cmd, priority, r)
@@ -197,23 +197,23 @@ func deleteRelease(r *release, rs releaseState, s *state) {
 // it will be purge deleted and installed in the same namespace using the new chart.
 // - If the release is NOT in the same namespace specified in the input,
 // it will be purge deleted and installed in the new namespace.
-func inspectUpgradeScenario(r *release, rs releaseState, s *state) {
+func inspectUpgradeScenario(r *release, rs releaseState) {
 
 	if r.Namespace == rs.Namespace {
 		if extractChartName(r.Chart) == getReleaseChartName(rs) && r.Version != getReleaseChartVersion(rs) {
 			// upgrade
-			upgradeRelease(r, s)
+			upgradeRelease(r)
 			logDecision("DECISION: release [ "+r.Name+" ] is desired to be upgraded. Planing this for you!", r.Priority, change)
 
 		} else if extractChartName(r.Chart) != getReleaseChartName(rs) {
-			reInstallRelease(r, rs, s)
+			reInstallRelease(r, rs)
 			logDecision("DECISION: release [ "+r.Name+" ] is desired to use a new Chart [ "+r.Chart+
 				" ]. I am planning a purge delete of the current release and will install it with the new chart in namespace [[ "+
 				r.Namespace+" ]]", r.Priority, change)
 
 		} else {
-			if diff := diffRelease(r, s); diff != "" {
-				upgradeRelease(r, s)
+			if diff := diffRelease(r); diff != "" {
+				upgradeRelease(r)
 				logDecision("DECISION: release [ "+r.Name+" ] is currently enabled and have some changed parameters. "+
 					"I will upgrade it!", r.Priority, change)
 			} else {
@@ -222,7 +222,7 @@ func inspectUpgradeScenario(r *release, rs releaseState, s *state) {
 			}
 		}
 	} else {
-		reInstallRelease(r, rs, s)
+		reInstallRelease(r, rs)
 		logDecision("DECISION: release [ "+r.Name+" ] is desired to be enabled in a new namespace [[ "+r.Namespace+
 			" ]]. I am planning a purge delete of the current release from namespace [[ "+rs.Namespace+" ]] "+
 			"and will install it for you in namespace [[ "+r.Namespace+" ]]", r.Priority, change)
@@ -233,7 +233,7 @@ func inspectUpgradeScenario(r *release, rs releaseState, s *state) {
 }
 
 // diffRelease diffs an existing release with the specified values.yaml
-func diffRelease(r *release, s *state) string {
+func diffRelease(r *release) string {
 	exitCode := 0
 	msg := ""
 	colorFlag := ""
@@ -247,7 +247,7 @@ func diffRelease(r *release, s *state) string {
 
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", helmCommandFromConfig(r, s) + " diff " + colorFlag + suppressDiffSecretsFlag + "upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + " " + getSetValues(r) + getSetStringValues(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r)},
+		Args:        []string{"-c", helmCommandFromConfig(r) + " diff " + colorFlag + suppressDiffSecretsFlag + "upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + " " + getSetValues(r) + getSetStringValues(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r)},
 		Description: "diffing release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 
@@ -263,10 +263,10 @@ func diffRelease(r *release, s *state) string {
 }
 
 // upgradeRelease upgrades an existing release with the specified values.yaml
-func upgradeRelease(r *release, s *state) {
+func upgradeRelease(r *release) {
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", helmCommandFromConfig(r, s) + " upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + " --force " + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r) + getDryRunFlags()},
+		Args:        []string{"-c", helmCommandFromConfig(r) + " upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + " --force " + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r) + getDryRunFlags()},
 		Description: "upgrading release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 
@@ -275,18 +275,18 @@ func upgradeRelease(r *release, s *state) {
 
 // reInstallRelease purge deletes a release and reinstalls it.
 // This is used when moving a release to another namespace or when changing the chart used for it.
-func reInstallRelease(r *release, rs releaseState, s *state) {
+func reInstallRelease(r *release, rs releaseState) {
 
 	delCmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", helmCommandFromConfig(r, s) + " delete --purge " + r.Name + getCurrentTillerNamespaceFlag(rs) + getTLSFlags(r) + getDryRunFlags()},
+		Args:        []string{"-c", helmCommandFromConfig(r) + " delete --purge " + r.Name + getCurrentTillerNamespaceFlag(rs) + getTLSFlags(r) + getDryRunFlags()},
 		Description: "deleting release [ " + r.Name + " ] from namespace [[ " + r.Namespace + " ]] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 	outcome.addCommand(delCmd, r.Priority, r)
 
 	installCmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", helmCommandFromConfig(r, s) + " install " + r.Chart + " --version " + r.Version + " -n " + r.Name + " --namespace " + r.Namespace + getValuesFiles(r) + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r) + getDryRunFlags()},
+		Args:        []string{"-c", helmCommandFromConfig(r) + " install " + r.Chart + " --version " + r.Version + " -n " + r.Name + " --namespace " + r.Namespace + getValuesFiles(r) + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r) + getDryRunFlags()},
 		Description: "installing release [ " + r.Name + " ] in namespace [[ " + r.Namespace + " ]] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 	outcome.addCommand(installCmd, r.Priority, r)

--- a/example.yaml
+++ b/example.yaml
@@ -23,6 +23,8 @@ settings:
   storageBackend: "secret" # default is configMap
   #slackWebhook:  "$slack" # or your slack webhook url
   #reverseDelete: false # reverse the priorities on delete
+  
+  #tillerless: true # runs helm in tillerless mode using
 
 # define your environments and their k8s namespaces
 namespaces:

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -62,12 +62,12 @@ func getAllReleases() tillerReleases {
 	// result := make(map[string]interface{})
 	var result tillerReleases
 	if _, ok := s.Namespaces["kube-system"]; !ok {
-		result.Releases = append(result.Releases, getTillerReleases("kube-system", s.Settings.Tillerless).Releases...)
+		result.Releases = append(result.Releases, getTillerReleases("kube-system").Releases...)
 	}
 
 	for ns, v := range s.Namespaces {
 		if v.InstallTiller || v.UseTiller {
-			result.Releases = append(result.Releases, getTillerReleases(ns, s.Settings.Tillerless).Releases...)
+			result.Releases = append(result.Releases, getTillerReleases(ns).Releases...)
 		}
 	}
 
@@ -75,7 +75,7 @@ func getAllReleases() tillerReleases {
 }
 
 // getTillerReleases gets releases deployed with a given Tiller (in a given namespace)
-func getTillerReleases(tillerNS string, tillerless bool) tillerReleases {
+func getTillerReleases(tillerNS string) tillerReleases {
 	v1, _ := version.NewVersion(helmVersion)
 	jsonConstraint, _ := version.NewConstraint(">=2.10.0-rc.1")
 	var outputFormat string
@@ -85,7 +85,7 @@ func getTillerReleases(tillerNS string, tillerless bool) tillerReleases {
 
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", helmCommand(tillerNS, tillerless) + " list --all --max 0 " + outputFormat + " --tiller-namespace " + tillerNS + getNSTLSFlags(tillerNS)},
+		Args:        []string{"-c", helmCommand(tillerNS) + " list --all --max 0 " + outputFormat + " --tiller-namespace " + tillerNS + getNSTLSFlags(tillerNS)},
 		Description: "listing all existing releases in namespace [ " + tillerNS + " ]...",
 	}
 
@@ -458,14 +458,14 @@ func cleanUntrackedReleases() {
 		for ns, releases := range toDelete {
 			for r := range releases {
 				logDecision("DECISION: untracked release found: release [ "+r+" ] from Tiller in namespace [ "+ns+" ]. It will be deleted.", -800, delete)
-				deleteUntrackedRelease(r, ns, s.Settings.Tillerless)
+				deleteUntrackedRelease(r, ns)
 			}
 		}
 	}
 }
 
 // deleteUntrackedRelease creates the helm command to purge delete an untracked release
-func deleteUntrackedRelease(release string, tillerNamespace string, tillerless bool) {
+func deleteUntrackedRelease(release string, tillerNamespace string) {
 
 	tls := ""
 	if tillerTLSEnabled(tillerNamespace) {
@@ -474,7 +474,7 @@ func deleteUntrackedRelease(release string, tillerNamespace string, tillerless b
 	}
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", helmCommand(tillerNamespace, tillerless) + " delete --purge " + release + " --tiller-namespace " + tillerNamespace + tls + getDryRunFlags()},
+		Args:        []string{"-c", helmCommand(tillerNamespace) + " delete --purge " + release + " --tiller-namespace " + tillerNamespace + tls + getDryRunFlags()},
 		Description: "deleting untracked release [ " + release + " ] from Tiller in namespace [[ " + tillerNamespace + " ]]",
 	}
 

--- a/init.go
+++ b/init.go
@@ -160,6 +160,11 @@ func init() {
 		s.print()
 	}
 
+	// validate that if we are running in tillerless mode, and we don't have the tiller plugin installed we should fail.
+	if !helmPluginExists("tiller") && s.Settings.Tillerless {
+		logError("ERROR: tillerless operation is specified and helm tiller plugin is not installed/configured correctly. Aborting!")
+	}
+
 	if !skipValidation {
 		// validate the desired state content
 		if len(files) > 0 {

--- a/main.go
+++ b/main.go
@@ -60,15 +60,17 @@ func main() {
 			logError(msg)
 		}
 
-		// check if helm Tiller is ready
-		for k, ns := range s.Namespaces {
-			if ns.InstallTiller || ns.UseTiller {
-				waitForTiller(k)
+		// check if helm Tiller is ready if we aren't running in tillerless mode.
+		if !s.Settings.Tillerless {
+			for k, ns := range s.Namespaces {
+				if ns.InstallTiller || ns.UseTiller {
+					waitForTiller(k)
+				}
 			}
-		}
 
-		if _, ok := s.Namespaces["kube-system"]; !ok {
-			waitForTiller("kube-system")
+			if _, ok := s.Namespaces["kube-system"]; !ok {
+				waitForTiller("kube-system")
+			}
 		}
 	}
 

--- a/release.go
+++ b/release.go
@@ -39,7 +39,10 @@ func validateRelease(appLabel string, r *release, names map[string]map[string]bo
 	if r.Name == "" {
 		r.Name = appLabel
 	}
-	if r.TillerNamespace != "" {
+
+	if s.Settings.Tillerless {
+		// if we are running in a tillerless environment then lets skip the tiller validation
+	} else if r.TillerNamespace != "" {
 		if ns, ok := s.Namespaces[r.TillerNamespace]; !ok {
 			return false, "tillerNamespace specified, but the namespace specified does not exist!"
 		} else if !ns.InstallTiller && !ns.UseTiller {

--- a/state.go
+++ b/state.go
@@ -32,6 +32,7 @@ type config struct {
 	StorageBackend string `yaml:"storageBackend"`
 	SlackWebhook   string `yaml:"slackWebhook"`
 	ReverseDelete  bool   `yaml:"reverseDelete"`
+	Tillerless     bool   `yaml:"tillerless"`
 }
 
 // state type represents the desired state of applications on a k8s cluster.


### PR DESCRIPTION
I was recently taking a look at helmsman, and one thing preventing me from adopting it is the fact that it doesn't support tillerless helm. I spent some time hacking togethor an example of what tillerless helm might look like in helmsman. The following code does work, but doesn't have any tests. Can we put this through review and figure out how we can integrate this into helmsman?
#151 