### PR TITLE
clean Tiller certs upon exit when not creating a context. Fixes #168

### DIFF
--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -364,6 +364,7 @@ func deployTiller(namespace string, serviceAccount string, defaultServiceAccount
 
 	tls := ""
 	if tillerTLSEnabled(namespace) {
+		shouldCleanup = true // needed to activate cleaning up the certs upon exit
 		tillerCert := namespace + "-tiller.cert"
 		tillerKey := namespace + "-tiller.key"
 		caCert := namespace + "-ca.cert"

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ var noColors bool
 var noFancy bool
 var noNs bool
 var nsOverride string
-var checkCleanup bool
+var shouldCleanup bool
 var skipValidation bool
 var applyLabels bool
 var keepUntrackedReleases bool
@@ -48,7 +48,7 @@ func main() {
 		if r, msg := createContext(); !r {
 			logError(msg)
 		}
-		checkCleanup = true
+		shouldCleanup = true
 	}
 
 	if apply || dryRun {
@@ -105,7 +105,7 @@ func main() {
 		p.execPlan()
 	}
 
-	if checkCleanup {
+	if shouldCleanup {
 		cleanup()
 	}
 


### PR DESCRIPTION
fixes #168 