### PR TITLE
Add annotation functionality to the namespace

### DIFF
--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -134,6 +134,7 @@ Options:
 > By default Tiller will be deployed into `kube-system` even if you don't define kube-system in the namespaces section. To prevent deploying Tiller into `kube-system, add kube-system in your namespaces section and set its installTiller to false.
 -**useTiller**: defines that you would like to use an existing Tiller from that namespace. Can't be set together with `installTiller`
 - **labels** : defines labels to be added to the namespace, doesn't remove existing labels but updates them if the label key exists with any other different value. You can define any key/value pairs. Default is empty.
+- **annotations** : defines annotations to be added to the namespace. It behaves the same way as the labels option.
 - **limits** : defines a [LimitRange](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/) to be configured on the namespace
 
 - **tillerServiceAccount**: defines what service account to use when deploying Tiller. If this is not set, the following options are considered:
@@ -172,6 +173,8 @@ clientCert = "gs://mybucket/mydir/helm.cert.pem"
 clientKey = "s3://mybucket/mydir/helm.key.pem"
 [namespaces.production.labels]
 env = "prod"
+[namespaces.production.annotations]
+iam.amazonaws.com/role = "dynamodb-reader"
 [namespaces.production.limits]
 [namespaces.production.limits.default]
 cpu = "300m"
@@ -208,6 +211,8 @@ namespaces:
         memory: "100Mi"
     labels:
       env: "prod"
+    annotations:
+      iam.amazonaws.com/role: "dynamodb-reader"
 ```
 
 ## Helm Repos

--- a/docs/how_to/define_namespaces.md
+++ b/docs/how_to/define_namespaces.md
@@ -161,6 +161,8 @@ clientCert = "gs://mybucket/mydir/helm.cert.pem"
 clientKey = "s3://mybucket/mydir/helm.key.pem"
 [namespaces.production.labels]
 env = "prod"
+[namespaces.production.annotations]
+iam.amazonaws.com/role = "dynamodb-reader"
 [namespaces.production.limits]
 [namespaces.production.limits.default]
 cpu = "300m"
@@ -197,6 +199,8 @@ namespaces:
         memory: "100Mi"
     labels:
       env: "prod"
+    annotations:
+      iam.amazonaws.com/role: "dynamodb-reader"
 ```
 
 You can read more about the `LimitRange` specification [here](https://docs.openshift.com/enterprise/3.2/dev_guide/compute_resources.html#dev-viewing-limit-ranges).

--- a/kube_helpers.go
+++ b/kube_helpers.go
@@ -61,6 +61,7 @@ func addNamespaces(namespaces map[string]namespace) {
 		for nsName, ns := range namespaces {
 			createNamespace(nsName)
 			labelNamespace(nsName, ns.Labels)
+			annotateNamespace(nsName, ns.Annotations)
 			setLimits(nsName, ns.Limits)
 		}
 	} else {
@@ -106,6 +107,23 @@ func labelNamespace(ns string, labels map[string]string) {
 		}
 	}
 }
+
+// annotateNamespace annotates a namespace with provided annotations
+func annotateNamespace(ns string, labels map[string]string) {
+	for k, v := range labels {
+		cmd := command{
+			Cmd:         "bash",
+			Args:        []string{"-c", "kubectl annotate --overwrite namespace/" + ns + " " + k + "=" + v},
+			Description: "annotating namespace  " + ns,
+		}
+
+		if exitCode, _ := cmd.exec(debug, verbose); exitCode != 0 {
+			log.Println("WARN: I could not annotate namespace [ " + ns + " with " + k + "=" + v +
+				" ]. It already exists. I am skipping this.")
+		}
+	}
+}
+
 
 // setLimits creates a LimitRange resource in the provided Namespace
 func setLimits(ns string, lims limits) {

--- a/namespace.go
+++ b/namespace.go
@@ -31,6 +31,7 @@ type namespace struct {
 	ClientKey            string            `yaml:"clientKey"`
 	Limits               limits            `yaml:"limits,omitempty"`
 	Labels               map[string]string `yaml:"labels"`
+	Annotations          map[string]string `yaml:"annotations"`
 }
 
 // checkNamespaceDefined checks if a given namespace is defined in the namespaces section of the desired state file

--- a/release_test.go
+++ b/release_test.go
@@ -10,7 +10,7 @@ func Test_validateRelease(t *testing.T) {
 		Metadata:     make(map[string]string),
 		Certificates: make(map[string]string),
 		Settings:     (config{}),
-		Namespaces:   map[string]namespace{"namespace": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)}},
+		Namespaces:   map[string]namespace{"namespace": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)}},
 		HelmRepos:    make(map[string]string),
 		Apps:         make(map[string]*release),
 	}

--- a/state_test.go
+++ b/state_test.go
@@ -34,7 +34,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https://192.168.99.100:8443",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -53,7 +53,7 @@ func Test_state_validate(t *testing.T) {
 				},
 				Settings: config{},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -77,7 +77,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https://192.168.99.100:8443",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -98,7 +98,7 @@ func Test_state_validate(t *testing.T) {
 					KubeContext: "minikube",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -122,7 +122,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https://192.168.99.100:8443",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -146,7 +146,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "$URI", // unset env
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -170,7 +170,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https//192.168.99.100:8443", // invalid url
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -193,7 +193,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https://192.168.99.100:8443",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -214,7 +214,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https://192.168.99.100:8443",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -238,7 +238,7 @@ func Test_state_validate(t *testing.T) {
 					ClusterURI:  "https://192.168.99.100:8443",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -256,7 +256,7 @@ func Test_state_validate(t *testing.T) {
 					KubeContext: "minikube",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -306,7 +306,7 @@ func Test_state_validate(t *testing.T) {
 					KubeContext: "minikube",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: nil,
 				Apps:      make(map[string]*release),
@@ -321,7 +321,7 @@ func Test_state_validate(t *testing.T) {
 					KubeContext: "minikube",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{},
 				Apps:      make(map[string]*release),
@@ -336,7 +336,7 @@ func Test_state_validate(t *testing.T) {
 					KubeContext: "minikube",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",
@@ -354,7 +354,7 @@ func Test_state_validate(t *testing.T) {
 					KubeContext: "minikube",
 				},
 				Namespaces: map[string]namespace{
-					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string)},
+					"staging": namespace{false, false, false, "", "", "", "", "", "", (limits{}), make(map[string]string), make(map[string]string)},
 				},
 				HelmRepos: map[string]string{
 					"stable": "https://kubernetes-charts.storage.googleapis.com",


### PR DESCRIPTION
Hi there,

I would like a submit a request for allowing annotations to be added to namespaces specify in the helmsman state file. We use kiam to manage AWS roles for our cluster and it involves annotating roles with allowed roles for the resources to assume. This will let us setup those annotation from within helmsman state file instead of needing to maintain a separate files for the namespaces.

This is my first time writing Go so hopefully this is fine. I pretty much copy from the label function since it should work in a similar fashion from Kubernetes' perspective. I also can't find the test files for kube_helpers, so if one does exists, please point me to it and I can write tests for it as well.

Thank you