### PR TITLE
make kube-system default binding to cluster-admin clusterrole

### DIFF
--- a/bindata.go
+++ b/bindata.go
@@ -6,13 +6,36 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 )
+
+func bindataRead(data []byte, name string) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewBuffer(data))
+	if err != nil {
+		return nil, fmt.Errorf("Read %q: %v", name, err)
+	}
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, gz)
+	clErr := gz.Close()
+
+	if err != nil {
+		return nil, fmt.Errorf("Read %q: %v", name, err)
+	}
+	if clErr != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
 
 type asset struct {
 	bytes []byte
@@ -45,18 +68,13 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
-var _dataRoleYaml = []byte(`kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
-metadata:
-  name: helmsman-tiller
-  namespace: <<namespace>>
-rules:
-- apiGroups: ["", "extensions", "apps"]
-  resources: ["*"]
-  verbs: ["*"]`)
+var _dataRoleYaml = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x74\x8e\xc1\x4a\x03\x31\x10\x86\xef\x79\x8a\x61\x8f\xe2\xae\xf4\x26\xa1\x14\xaa\x2e\x7a\xb0\x1e\xaa\x08\x22\x1e\x26\xe9\x40\x43\xd3\x4c\x98\x49\x8a\xf8\xf4\x92\x20\x7b\xf3\x34\xf3\xfd\x3f\x33\x7c\xa7\x90\x0e\x16\xf6\x1c\xc9\x60\x0e\xef\x24\x1a\x38\x59\x10\x87\x7e\xc2\x5a\x8e\x2c\xe1\x07\x4b\xe0\x34\x9d\x6e\x75\x0a\x7c\x73\x59\x39\x2a\xb8\x32\x67\x2a\x78\xc0\x82\xd6\x00\x24\x3c\x93\x85\xf5\x5a\x38\xd2\xd8\x60\xb3\xf9\x4b\x35\xa3\xef\xd5\x02\xbd\x8a\xe8\x28\x6a\x3b\x05\xb8\xdf\xcf\xdb\xb7\xf9\x61\xbc\xfb\xb0\xf0\x34\x3f\xef\x5e\x77\xdb\x17\x23\x35\x92\x5a\x33\x02\xe6\xf0\x28\x5c\xb3\x5a\xf8\x1c\x86\x6b\x18\x1c\x16\x7f\x6c\x0b\x7d\x17\x4a\xcd\x56\x1b\x61\xce\x7d\xfe\x2b\x3e\x7c\x19\x00\x21\xe5\x2a\x9e\xfa\xb7\xab\x1e\x5d\x48\xdc\x82\xbf\x01\x00\x00\xff\xff\xfa\x4b\x3c\xe3\x0e\x01\x00\x00")
 
 func dataRoleYamlBytes() ([]byte, error) {
-	return _dataRoleYaml, nil
+	return bindataRead(
+		_dataRoleYaml,
+		"data/role.yaml",
+	)
 }
 
 func dataRoleYaml() (*asset, error) {
@@ -65,7 +83,7 @@ func dataRoleYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "data/role.yaml", size: 198, mode: os.FileMode(420), modTime: time.Unix(1531758991, 0)}
+	info := bindataFileInfo{name: "data/role.yaml", size: 270, mode: os.FileMode(420), modTime: time.Unix(1550050901, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -164,7 +182,6 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
-
 var _bintree = &bintree{nil, map[string]*bintree{
 	"data": &bintree{nil, map[string]*bintree{
 		"role.yaml": &bintree{dataRoleYaml, map[string]*bintree{}},
@@ -217,3 +234,4 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
+

--- a/data/role.yaml
+++ b/data/role.yaml
@@ -1,8 +1,10 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: helmsman-tiller
+  name: <<role-name>>
   namespace: <<namespace>>
+  labels:
+    CREATED-BY: HELMSMAN
 rules:
 - apiGroups: ["", "batch", "extensions", "apps", "rbac.authorization.k8s.io"]
   resources: ["*"]

--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -132,7 +132,7 @@ Options:
 > For the definition of what a protected namespace means, check the [protection guide](how_to/protect_namespaces_and_releases.md)
 - **installTiller**: defines if Tiller should be deployed in this namespace or not. Default is false. Any chart desired to be deployed into a namespace with a Tiller deployed, will be deployed using that Tiller and not the one in kube-system unless you use the `TillerNamespace` option (see the [Apps](#apps) section below) to use another Tiller.
 > By default Tiller will be deployed into `kube-system` even if you don't define kube-system in the namespaces section. To prevent deploying Tiller into `kube-system, add kube-system in your namespaces section and set its installTiller to false.
--**tillerRole**: specify the role to use.  If 'cluster-admin' a clusterrolebinding will be used else a rolebinding will be used.
+-**tillerRole**: specify the role to use.  If 'cluster-admin' a clusterrolebinding will be used else a role with a single namespace scope will be created and bound with a rolebinding.
 -**useTiller**: defines that you would like to use an existing Tiller from that namespace. Can't be set together with `installTiller`
 - **labels** : defines labels to be added to the namespace, doesn't remove existing labels but updates them if the label key exists with any other different value. You can define any key/value pairs. Default is empty.
 - **annotations** : defines annotations to be added to the namespace. It behaves the same way as the labels option.
@@ -141,7 +141,7 @@ Options:
 - **tillerServiceAccount**: defines what service account to use when deploying Tiller. If this is not set, the following options are considered:
 
   1. If the `serviceAccount` defined in the `settings` section exists in the namespace you want to deploy Tiller in, it will be used, else
-  2. Helmsman creates the service account in that namespace and binds it to a role. If the namespace is kube-system, the service account is bound to `cluster-admin` clusterrole. Otherwise, a new role called `helmsman-tiller` is created in that namespace and only gives access to that namespace. The role can be overriden with the tillerRole option.
+  2. Helmsman creates the service account in that namespace and binds it to a (cluster)role. If the namespace is kube-system and `tillerRole` is unset or is set to cluster-admin, the service account is bound to `cluster-admin` clusterrole. Otherwise, if you specified a `tillerRole`, a new role with that name is created and bound to the service account with rolebinding. If `tillerRole` is unset (for namespaces other than kube-system), the role is called `helmsman-tiller` and is created in the specified namespace to only gives access to that namespace. The custom role is created from a [yaml template](../data/role.yaml).
 
   > If `installTiller` is not defined or set to false, this flag is ignored.
 


### PR DESCRIPTION
this is a follow up to #182 and #187 
We need to keep the new behaviour backward compatible and therefore kube-system without `tillerRole` specified, should by default still get a cluster-admin clusterrole. This can still be overriden by the user if needed with `tillerRole`. This PR addresses this. 
Also this PR fixes the hardcoded custom role name `helmsman-tiller` which now needs to match `tillerRole` when provided. 
Additionally, some minor updates on docs and code comments.