### PR TITLE
Add support for externally configured helm repos

### DIFF
--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -251,6 +251,28 @@ helmRepos:
   myGCSrepo: "gs://my-GCS-private-repo/charts"
 ```
 
+## Preconfigured Helm Repos
+
+Optional : Yes.
+
+Synopsis: defines the list of helm repositories that the helmsman will consider already preconfigured and thus will not try to overwrite it's configuration.
+
+The primary use-case is if you have some helm repositories that require HTTP basic authentication and you don't want to store the password into the helmsman.yaml. In this case you can execute the following sequence to have those repositories configured:
+
+Set up the helmsman configuration:
+
+```toml
+preconfiguredHelmRepos = [ "myrepo1", "myrepo2" ]
+```
+
+```yaml
+preconfiguredHelmRepos:
+- myrepo1
+- myrepo2
+```
+
+> In this case you will manually need to execute `helm repo add myrepo1 <URL> --username= --password=`
+
 ## Apps
 
 Optional : Yes.

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -294,6 +294,7 @@ func addHelmRepos(repos map[string]string) (bool, string) {
 		if strings.HasPrefix(url, "gs://") {
 			gcs.Auth()
 		}
+
 		cmd := command{
 			Cmd:         "bash",
 			Args:        []string{"-c", "helm repo add " + repoName + " " + strconv.Quote(url)},

--- a/state.go
+++ b/state.go
@@ -22,12 +22,13 @@ type config struct {
 
 // state type represents the desired state of applications on a k8s cluster.
 type state struct {
-	Metadata     map[string]string    `yaml:"metadata"`
-	Certificates map[string]string    `yaml:"certificates"`
-	Settings     config               `yaml:"settings"`
-	Namespaces   map[string]namespace `yaml:"namespaces"`
-	HelmRepos    map[string]string    `yaml:"helmRepos"`
-	Apps         map[string]*release  `yaml:"apps"`
+	Metadata               map[string]string    `yaml:"metadata"`
+	Certificates           map[string]string    `yaml:"certificates"`
+	Settings               config               `yaml:"settings"`
+	Namespaces             map[string]namespace `yaml:"namespaces"`
+	HelmRepos              map[string]string    `yaml:"helmRepos"`
+	PreconfiguredHelmRepos []string             `yaml:"preconfiguredHelmRepos"`
+	Apps                   map[string]*release  `yaml:"apps"`
 }
 
 // validate validates that the values specified in the desired state are valid according to the desired state spec.

--- a/utils.go
+++ b/utils.go
@@ -141,6 +141,15 @@ func toFile(file string, s *state) {
 	}
 }
 
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 func resolvePaths(relativeToFile string, s *state) {
 	dir := filepath.Dir(relativeToFile)
 
@@ -161,6 +170,7 @@ func resolvePaths(relativeToFile string, s *state) {
 		if v.Chart != "" {
 			var repoOrDir = filepath.Dir(v.Chart)
 			_, isRepo := s.HelmRepos[repoOrDir]
+			isRepo = isRepo || stringInSlice(repoOrDir, s.PreconfiguredHelmRepos)
 			if !isRepo {
 				// if there is no repo for the chart, we assume it's intended to be a local path
 


### PR DESCRIPTION
This patch adds support for externally configured helm repositories,
which is a handy tool if you are using Artifcatory as helm repository
server.

In our case, we don't want to push the basic auth credentials to the repositories, but we will make sure that all developers update their helm settings to contain the correct credentials.