### PR TITLE
Dehardcoding LimitRange type to be able to set limits for Pod

### DIFF
--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -75,7 +75,7 @@ certificates:
 
 ## Settings
 
-Optional : Yes. 
+Optional : Yes.
 
 Synopsis: provides settings for connecting to your k8s cluster and configuring Helm's Tiller in the cluster.
 
@@ -84,7 +84,7 @@ Synopsis: provides settings for connecting to your k8s cluster and configuring H
 Options:
 - **kubeContext** : the kube context you want Helmsman to use or create. Helmsman will try connect to this context first, if it does not exist, it will try to create it (i.e. connect to a k8s cluster) using the options below.
 
-The following options can be skipped if your kubectl context is already created and you don't want Helmsman to connect kubectl to your cluster for you. 
+The following options can be skipped if your kubectl context is already created and you don't want Helmsman to connect kubectl to your cluster for you.
 
 - **username**   : the username to be used for kubectl credentials.
 - **password**   : an environment variable name (starting with `$`) where your password is stored. Get the password from your k8s admin or consult k8s docs on how to get/set it.
@@ -182,13 +182,18 @@ clientKey = "s3://mybucket/mydir/helm.key.pem"
 env = "prod"
 [namespaces.production.annotations]
 iam.amazonaws.com/role = "dynamodb-reader"
-[namespaces.production.limits]
+[[namespaces.production.limits]]
+type = "Container"
 [namespaces.production.limits.default]
 cpu = "300m"
 memory = "200Mi"
 [namespaces.production.limits.defaultRequest]
 cpu = "200m"
 memory = "100Mi"
+[[namespaces.production.limits]]
+type = "Pod"
+[namespaces.production.limits.max]
+memory = "300Mi"
 ```
 
 ```yaml
@@ -210,12 +215,16 @@ namespaces:
     clientCert: "gs://mybucket/mydir/helm.cert.pem"
     clientKey: "s3://mybucket/mydir/helm.key.pem"
     limits:
-      default:
-        cpu: "300m"
-        memory: "200Mi"
-      defaultRequest:
-        cpu: "200m"
-        memory: "100Mi"
+      - type: Container
+        default:
+          cpu: "300m"
+          memory: "200Mi"
+        defaultRequest:
+          cpu: "200m"
+          memory: "100Mi"
+      - type: Pod
+        max:
+          memory: "300Mi"
     labels:
       env: "prod"
     annotations:
@@ -239,7 +248,7 @@ Authenticating to private helm repos:
     - Or, set `GCLOUD_CREDENTIALS` environment variable to contain the content of the credentials.json file.
 
 Options:
-- you can define any key/value pairs where key is the repo name and value is a valid URI for the repo. Basic auth info can be added in the repo URL as in the example below. 
+- you can define any key/value pairs where key is the repo name and value is a valid URI for the repo. Basic auth info can be added in the repo URL as in the example below.
 
 Example:
 

--- a/docs/how_to/README.md
+++ b/docs/how_to/README.md
@@ -11,23 +11,23 @@ This page contains a list of guides on how to use Helmsman.
     - [Using the current kube context](settings/current_kube_context.md)
     - [Connecting with certificates](settings/creating_kube_context_with_certs.md)
     - [Connecting with bearer token](settings/creating_kube_context_with_token.md)
-- Defining Namespaces    
+- Defining Namespaces
     - [Create namespaces](namespaces/create.md)
     - [Label namespaces](namespaces/labels_and_annotations.md)
     - [Set resource limits for namespaces](namespaces/limits.md)
     - [Protecting namespaces](namespaces/protection.md)
 - Deploying Helm Tiller
-    - [Using existing Tillers](tiller/existing.md) 
+    - [Using existing Tillers](tiller/existing.md)
     - [Deploy shared Tiller in kube-system](tiller/shared.md)
     - [Prevent Deploying Tiller in kube-system](tiller/prevent_tiller_in_kube_system.md)
     - [Deploy Multiple Tillers with custom setup for each](tiller/multitenancy.md)
     - [Deploy apps with specific Tillers](deploy_apps_with_specific_tiller.md)
 - Defining Helm repositories
-    - [Using default helm repos](helm_repos/default.md) 
+    - [Using default helm repos](helm_repos/default.md)
     - [Using private repos in Google GCS](helm_repos/gcs.md)
-    - [Using private repos in AWS S3](helm_repos/s3.md)    
+    - [Using private repos in AWS S3](helm_repos/s3.md)
     - [Using private repos with basic auth](helm_repos/basic_auth.md)
-    - [Using pre-configured repos](helm_repos/pre_configured.md) 
+    - [Using pre-configured repos](helm_repos/pre_configured.md)
     - [Using local charts](helm_repos/local.md)
 - Manipulating Apps
     - [Basic operations](apps/basic.md)
@@ -36,8 +36,8 @@ This page contains a list of guides on how to use Helmsman.
     - [Protect releases (apps)](apps/protection.md)
     - [Moving releases (apps) across namespaces](apps/moving_across_namespaces.md)
     - [Override defined namespaces](apps/override_namespaces.md)
-    - [Run helm tests for deployed releases (apps)](apps/helm_tests.md)  
-    - [Define the order of apps operations](apps/order.md)  
+    - [Run helm tests for deployed releases (apps)](apps/helm_tests.md)
+    - [Define the order of apps operations](apps/order.md)
     - [Delete all releases (apps)](apps/destroy.md)
 - Running Helmsman in different environments
     - [Running Helmsman in CI](deployment/ci.md)

--- a/docs/how_to/namespaces/limits.md
+++ b/docs/how_to/namespaces/limits.md
@@ -2,23 +2,29 @@
 version: v1.8.0
 ---
 
-# Define resource limits for namespaces 
+# Define resource limits for namespaces
 
 You can define namespaces to be used in your cluster. If they don't exist, Helmsman will create them for you. You can also define how much resource limits to set for each namespace.
 
-You can read more about the `LimitRange` specification [here](https://docs.openshift.com/enterprise/3.2/dev_guide/compute_resources.html#dev-viewing-limit-ranges).
+You can read more about the `LimitRange` specification [here](https://docs.openshift.com/container-platform/3.11/dev_guide/compute_resources.html#dev-limit-ranges).
 
 ```toml
 #...
 
 [namespaces]
 [namespaces.staging]
-  [namespaces.staging.limits.default]
-    cpu = "300m"
-    memory = "200Mi"
-  [namespaces.staging.limits.defaultRequest]
-    cpu = "200m"
-    memory = "100Mi"
+  [[namespaces.staging.limits]]
+    type = "Container"
+    [namespaces.staging.limits.default]
+      cpu = "300m"
+      memory = "200Mi"
+    [namespaces.staging.limits.defaultRequest]
+      cpu = "200m"
+      memory = "100Mi"
+  [[namespaces.staging.limits]]
+    type = "Pod"
+    [namespaces.staging.limits.max]
+      memory = "300Mi"
 [namespaces.production]
 
 #...
@@ -29,12 +35,16 @@ You can read more about the `LimitRange` specification [here](https://docs.opens
 namespaces:
   staging:
     limits:
-      default:
-        cpu: "300m"
-        memory: "200Mi"
-      defaultRequest:
-        cpu: "200m"
-        memory: "100Mi"
+      - type: Container
+        default:
+          cpu: "300m"
+          memory: "200Mi"
+        defaultRequest:
+          cpu: "200m"
+          memory: "100Mi"
+      - type: Pod
+        max:
+          memory: "300Mi"
   production:
 
 ```

--- a/example.toml
+++ b/example.toml
@@ -38,13 +38,18 @@
 [namespaces]
   [namespaces.production]
     protected = true
-    [namespaces.production.limits]
-      [namespaces.production.limits.default]
-        cpu = "300m"
-        memory = "200Mi"
-      [namespaces.production.limits.defaultRequest]
-        cpu = "200m"
-        memory = "100Mi"
+    [[namespaces.production.limits]]
+      type = "Container"
+        [namespaces.production.limits.default]
+          cpu = "300m"
+          memory = "200Mi"
+        [namespaces.production.limits.defaultRequest]
+          cpu = "200m"
+          memory = "100Mi"
+    [[namespaces.production.limits]]
+      type = "Pod"
+        [namespaces.production.limits.max]
+          memory = "300Mi"
   [namespaces.staging]
     protected = false
     installTiller = true

--- a/example.toml
+++ b/example.toml
@@ -40,16 +40,16 @@
     protected = true
     [[namespaces.production.limits]]
       type = "Container"
-        [namespaces.production.limits.default]
-          cpu = "300m"
-          memory = "200Mi"
-        [namespaces.production.limits.defaultRequest]
-          cpu = "200m"
-          memory = "100Mi"
+      [namespaces.production.limits.default]
+        cpu = "300m"
+        memory = "200Mi"
+      [namespaces.production.limits.defaultRequest]
+        cpu = "200m"
+        memory = "100Mi"
     [[namespaces.production.limits]]
       type = "Pod"
-        [namespaces.production.limits.max]
-          memory = "300Mi"
+      [namespaces.production.limits.max]
+        memory = "300Mi"
   [namespaces.staging]
     protected = false
     installTiller = true

--- a/example.yaml
+++ b/example.yaml
@@ -32,12 +32,16 @@ namespaces:
   production:
     protected: true
     limits:
-      default:
-        cpu: "300m"
-        memory: "200Mi"
-      defaultRequest:
-        cpu: "200m"
-        memory: "100Mi"
+      - type: Container
+        default:
+          cpu: "300m"
+          memory: "200Mi"
+        defaultRequest:
+          cpu: "200m"
+          memory: "100Mi"
+      - type: Pod
+        max:
+          memory: "300Mi"
   staging:
     protected: false
     installTiller: true

--- a/kube_helpers.go
+++ b/kube_helpers.go
@@ -134,18 +134,18 @@ func annotateNamespace(ns string, labels map[string]string) {
 // setLimits creates a LimitRange resource in the provided Namespace
 func setLimits(ns string, lims limits) {
 
-	if lims == (limits{}) {
+	if len(lims) == 0 {
 		return
 	}
 
-	definition := `---
+	definition := `
+---
 apiVersion: v1
 kind: LimitRange
 metadata:
   name: limit-range
 spec:
   limits:
-  - type: Container
 `
 	d, err := yaml.Marshal(&lims)
 	if err != nil {

--- a/namespace.go
+++ b/namespace.go
@@ -6,16 +6,18 @@ import (
 
 // resources type
 type resources struct {
-	Cpu    string `yaml:"cpu,omitempty"`
+	CPU    string `yaml:"cpu,omitempty"`
 	Memory string `yaml:"memory,omitempty"`
 }
 
 // limits type
-type limits struct {
-	Max            resources `yaml:"max,omitempty"`
-	Min            resources `yaml:"min,omitempty"`
-	Default        resources `yaml:"default,omitempty"`
-	DefaultRequest resources `yaml:"defaultRequest,omitempty"`
+type limits []struct {
+	Max                  resources `yaml:"max,omitempty"`
+	Min                  resources `yaml:"min,omitempty"`
+	Default              resources `yaml:"default,omitempty"`
+	DefaultRequest       resources `yaml:"defaultRequest,omitempty"`
+	MaxLimitRequestRatio resources `yaml:"maxLimitRequestRatio,omitempty"`
+	LimitType            string    `yaml:"type"`
 }
 
 // namespace type represents the fields of a namespace


### PR DESCRIPTION
There is an outstanding issue in Kubernetes docs about missing Pod type in LimitRange doc - https://github.com/kubernetes/website/issues/9585, so i guess that's why it wasn't added. Although this type exists and we are successfully using it for some time. The proof can be found here for example - https://docs.openshift.com/container-platform/3.11/dev_guide/compute_resources.html#dev-limit-ranges