### PR TITLE
Typo on word labels

### DIFF
--- a/docs/how_to/namespaces/labels_and_annotations.md
+++ b/docs/how_to/namespaces/labels_and_annotations.md
@@ -25,7 +25,7 @@ You can define namespaces to be used in your cluster. If they don't exist, Helms
 
 namespaces:
   staging:
-    lables:
+    labels:
       env: "staging"
   production:
     annotations:


### PR DESCRIPTION
Typos on word for labels in namespaces labels example