### PR TITLE
Add -target flag to limit execution to specific app

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ To show debugging details:
 To run a dry-run:
 ``` $ helmsman --debug --dry-run -f example.toml ```
 
+To limit execution to specific application:
+``` $ helmsman --debug --dry-run --target artifactory -f example.toml ```
+
 # Features
 
 - **Built for CD**: Helmsman can be used as a docker image or a binary.

--- a/decision_maker.go
+++ b/decision_maker.go
@@ -27,6 +27,14 @@ func makePlan(s *state) *plan {
 // decide makes a decision about what commands (actions) need to be executed
 // to make a release section of the desired state come true.
 func decide(r *release, s *state) {
+	// check for presence in defined targets
+	if len(targetMap) > 0 {
+		if _, ok := targetMap[r.Name]; !ok {
+			logDecision("DECISION: release [ "+r.Name+" ] is ignored by target flag. Skipping.", r.Priority, noop)
+			return
+		}
+	}
+
 	if destroy {
 		if ok, rs := helmReleaseExists(r, "DEPLOYED"); ok {
 			deleteRelease(r, rs)

--- a/docs/how_to/limit-deployment-to-specific-apps.md
+++ b/docs/how_to/limit-deployment-to-specific-apps.md
@@ -1,0 +1,47 @@
+---
+version: v1.9.0
+---
+
+# limit execution to explicitly defined apps
+
+Starting from v1.9.0, Helmsman allows you to pass the `-target` flag multiple times to specify multiple apps
+that limits apps considered by Helmsman during this specific execution. 
+Thanks to this one can deploy specific applications among all defined for an environment.
+
+## An example
+
+having environment defined with such apps:
+
+* example.yaml:
+```yaml
+...
+apps:
+    jenkins:
+      namespace: "staging" # maps to the namespace as defined in namespaces above
+      enabled: true # change to false if you want to delete this app release empty: false:
+      chart: "stable/jenkins" # changing the chart name means delete and recreate this chart
+      version: "0.14.3" # chart version
+
+    artifactory:
+      namespace: "production" # maps to the namespace as defined in namespaces above
+      enabled: true # change to false if you want to delete this app release empty: false:
+      chart: "stable/artifactory" # changing the chart name means delete and recreate this chart
+      version: "7.0.6" # chart version
+...
+```
+
+running Helmsman with `-f example.yaml` would result in checking state and invoking deployment for both jenkins and artifactory application.
+
+With `-target` flag in command like
+
+```bash
+$ helmsman -f example.yaml -target artifactory ...
+```
+
+one can execute Helmsman's environment defined with example.yaml limited to only one `artifactory` app. Others are ignored until the flag is defined.
+
+Multiple applications can be set with `-target`, like
+
+```bash
+$ helmsman -f example.yaml -target artifactory -target jenkins ...
+```

--- a/init.go
+++ b/init.go
@@ -44,6 +44,7 @@ func init() {
 	flag.BoolVar(&apply, "apply", false, "apply the plan directly")
 	flag.BoolVar(&debug, "debug", false, "show the execution logs")
 	flag.BoolVar(&dryRun, "dry-run", false, "apply the dry-run option for helm commands.")
+	flag.Var(&target, "target", "limit execution to specific app.")
 	flag.BoolVar(&destroy, "destroy", false, "delete all deployed releases. Purge delete is used if the purge option is set to true for the releases.")
 	flag.BoolVar(&v, "v", false, "show the version")
 	flag.BoolVar(&verbose, "verbose", false, "show verbose execution logs")
@@ -179,6 +180,13 @@ func init() {
 	if applyLabels {
 		for _, r := range s.Apps {
 			labelResource(r)
+		}
+	}
+
+	if len(target) > 0 {
+		targetMap = map[string]bool{}
+		for _, v := range target {
+			targetMap[v] = true
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -38,6 +38,8 @@ var appVersion = "v1.8.1"
 var helmVersion string
 var kubectlVersion string
 var dryRun bool
+var target stringArray
+var targetMap map[string]bool
 var destroy bool
 var showDiff bool
 var suppressDiffSecrets bool


### PR DESCRIPTION
Since feature requested in #230 would be a significant improvement in our helmsman-based stack, I'd like to propose a `-target` flag which limits an execution to apps defined with such. 