### PR TITLE
Set proper stdout and stderr streams for logs; trim error message on no verbose

### DIFF
--- a/init.go
+++ b/init.go
@@ -26,11 +26,11 @@ const (
 )
 
 func printUsage() {
-	fmt.Println(banner + "\n")
-	fmt.Println("Helmsman version: " + appVersion)
-	fmt.Println("Helmsman is a Helm Charts as Code tool which allows you to automate the deployment/management of your Helm charts.")
-	fmt.Println()
-	fmt.Println("Usage: helmsman [options]")
+	log.Println(banner + "\n")
+	log.Println("Helmsman version: " + appVersion)
+	log.Println("Helmsman is a Helm Charts as Code tool which allows you to automate the deployment/management of your Helm charts.")
+	log.Println()
+	log.Println("Usage: helmsman [options]")
 	flag.PrintDefaults()
 }
 
@@ -57,6 +57,8 @@ func init() {
 	flag.BoolVar(&keepUntrackedReleases, "keep-untracked-releases", false, "keep releases that are managed by Helmsman and are no longer tracked in your desired state.")
 	flag.BoolVar(&showDiff, "show-diff", false, "show helm diff results. Can expose sensitive information.")
 	flag.BoolVar(&suppressDiffSecrets, "suppress-diff-secrets", false, "don't show secrets in helm diff output.")
+
+	log.SetOutput(os.Stdout)
 
 	flag.Usage = printUsage
 	flag.Parse()

--- a/plan.go
+++ b/plan.go
@@ -93,7 +93,11 @@ func (p plan) execPlan() {
 
 	for _, cmd := range p.Commands {
 		if exitCode, msg := cmd.Command.exec(debug, verbose); exitCode != 0 {
-			logError("Command returned with exit code: " + string(exitCode) + ". And error message: " + msg)
+			var errorMsg string
+			if errorMsg = msg; !verbose {
+				errorMsg = strings.Split(msg, "---")[0]
+			}
+			logError("Command returned with exit code: " + string(exitCode) + ". And error message: " + errorMsg)
 		} else {
 			log.Println(style.Cyan(msg))
 			if cmd.targetRelease != nil && !dryRun {

--- a/plan.go
+++ b/plan.go
@@ -116,10 +116,10 @@ func (p plan) printPlanCmds() {
 
 // printPlan prints the decisions made in a plan.
 func (p plan) printPlan() {
-	fmt.Println("----------------------")
+	log.Println("----------------------")
 	log.Println(style.Bold(style.Green("INFO: Plan generated at: " + p.Created.Format("Mon Jan _2 2006 15:04:05"))))
 	for _, decision := range p.Decisions {
-		fmt.Println(style.Colorize(decision.Description+" -- priority: "+strconv.Itoa(decision.Priority), decisionColor[decision.Type]))
+		log.Println(style.Colorize(decision.Description+" -- priority: "+strconv.Itoa(decision.Priority), decisionColor[decision.Type]))
 	}
 }
 

--- a/utils.go
+++ b/utils.go
@@ -402,6 +402,7 @@ func logError(msg string) {
 	if _, err := url.ParseRequestURI(s.Settings.SlackWebhook); err == nil {
 		notifySlack(msg, s.Settings.SlackWebhook, true, apply)
 	}
+	log.SetOutput(os.Stderr)
 	log.Fatal(style.Bold(style.Red(msg)))
 }
 


### PR DESCRIPTION
Here I'd like to fix inconsistency of logs' streams. Some of them go to stdout, some to stderr. With this change, only errors go to stderr and other output is directed to stdout.
This allowed me to introduce proper error message trimming when no verbose flag is set. This will resolve an issue, when one runs -dry-run on a chart with yaml syntax, where with error message it exposes all the templated files it created (so potential secrets as well). 

Before (with or without verbose set):
```
2019/04/24 19:32:42 INFO: Executing the plan ... 
2019/04/24 19:32:44 Command returned with exit code: . And error message: Error: YAML parse error on eg-versions-agent/charts/eg-versions-agent/templates/ingress.yaml: error converting YAML to JSON: yaml: line 19: mapping values are not allowed in this context

---
# Source: eg-versions-agent/charts/eg-versions-agent/templates/sa.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: eg-versions-agent
  labels:
    app: eg-versions-agent
    chart: eg-versions-agent-0.1.0
    release: eg-versions-agent
    heritage: Tiller
---
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
[...]
```

and after my change (run without verbose set):
```
2019/04/24 19:24:18 INFO: Executing the plan ... 
2019/04/24 19:24:18 INFO: installing release [ eg-versions-agent ] in namespace [[ monitoring ]] using Tiller in [ kube-system ]
2019/04/24 19:24:19 Command returned with exit code: . And error message: Error: YAML parse error on eg-versions-agent/charts/eg-versions-agent/templates/ingress.yaml: error converting YAML to JSON: yaml: line 19: mapping values are not allowed in this context
```

so it's not exposing anything confidential anymore, which fixes #238