### PR TITLE
Improve temporary dir handling.

### DIFF
--- a/init.go
+++ b/init.go
@@ -133,6 +133,10 @@ func init() {
 		}
 	}
 
+	// wipe & create a temporary directory
+	os.RemoveAll(tempFilesDir)
+	_ = os.MkdirAll(tempFilesDir, 0755)
+
 	// read the TOML/YAML desired state file
 	var fileState state
 	for _, f := range files {

--- a/main.go
+++ b/main.go
@@ -43,11 +43,15 @@ var destroy bool
 var showDiff bool
 var suppressDiffSecrets bool
 
-const tempFilesDir = "helmsman-temp-files"
+const tempFilesDir = ".helmsman-tmp"
 const stableHelmRepo = "https://kubernetes-charts.storage.googleapis.com"
 const incubatorHelmRepo = "http://storage.googleapis.com/kubernetes-charts-incubator"
 
 func main() {
+	// delete temp files with substituted env vars when the program terminates
+	defer os.RemoveAll(tempFilesDir)
+	defer cleanup()
+
 	// set the kubecontext to be used Or create it if it does not exist
 	if !setKubeContext(s.Settings.KubeContext) {
 		if r, msg := createContext(); !r {
@@ -111,8 +115,6 @@ func main() {
 		p.execPlan()
 	}
 
-	cleanup()
-
 	log.Println("INFO: completed successfully!")
 }
 
@@ -166,6 +168,4 @@ func cleanup() {
 		}
 	}
 
-	// delete temp files with substituted env vars
-	os.RemoveAll(tempFilesDir)
 }

--- a/utils.go
+++ b/utils.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -151,16 +152,13 @@ func substituteEnvInYaml(file string) string {
 	}
 	yamlFile := substituteEnv(string(rawYamlFile))
 
-	// create a temp directory
-	if _, err := os.Stat(tempFilesDir); os.IsNotExist(err) {
-		err = os.MkdirAll(tempFilesDir, 0755)
-		if err != nil {
-			logError(err.Error())
-		}
+	dir, err := ioutil.TempDir(tempFilesDir, "tmp")
+	if err != nil {
+		logError(err.Error())
 	}
 
 	// output file contents with env variables substituted into temp files
-	outFile := tempFilesDir + string(os.PathSeparator) + filepath.Base(file)
+	outFile := path.Join(dir, filepath.Base(file))
 	err = ioutil.WriteFile(outFile, []byte(yamlFile), 0644)
 	if err != nil {
 		logError(err.Error())


### PR DESCRIPTION
 - renamed temp dir from `helmsman-temp-dir` to `.helmsman-tmp`
 - defer cleanup of temporary files at the start of main()
 - use ioutil TempDir() instead of custom code

There's still one outstanding issue which is that the temp dir won't be
cleaned up properly if the program exits early while if an error happens
inside init().

I had an issue with deployments flapping, and it turned out the cause was a conflict in the temporary directory. This change puts each file into a separate path.