### PR TITLE
Do not delete untracked releases if the target flag is set.

### DIFF
--- a/decision_maker_test.go
+++ b/decision_maker_test.go
@@ -76,3 +76,118 @@ func Test_getValuesFiles(t *testing.T) {
 		})
 	}
 }
+
+func Test_decide(t *testing.T) {
+	type args struct {
+		r *release
+		s *state
+	}
+	tests := []struct {
+		name       string
+		targetFlag []string
+		args       args
+		want       decisionType
+	}{
+		{
+			name:       "decide() - targetMap does not contain this service - skip",
+			targetFlag: []string{"someOtherRelease"},
+			args: args{
+				r: &release{
+					Name:      "release1",
+					Namespace: "namespace",
+					Enabled:   true,
+				},
+				s: &state{},
+			},
+			want: noop,
+		},
+		{
+			name:       "decide() - targetMap does not contain this service - skip",
+			targetFlag: []string{"someOtherRelease", "norThisOne"},
+			args: args{
+				r: &release{
+					Name:      "release1",
+					Namespace: "namespace",
+					Enabled:   true,
+				},
+				s: &state{},
+			},
+			want: noop,
+		},
+		{
+			name:       "decide() - targetMap is empty - will install",
+			targetFlag: []string{},
+			args: args{
+				r: &release{
+					Name:      "release4",
+					Namespace: "namespace",
+					Enabled:   true,
+				},
+				s: &state{},
+			},
+			want: create,
+		},
+		{
+			name:       "decide() - targetMap is exactly this service - will install",
+			targetFlag: []string{"thisRelease"},
+			args: args{
+				r: &release{
+					Name:      "thisRelease",
+					Namespace: "namespace",
+					Enabled:   true,
+				},
+				s: &state{},
+			},
+			want: create,
+		},
+		{
+			name:       "decide() - targetMap contains this service - will install",
+			targetFlag: []string{"notThisOne", "thisRelease"},
+			args: args{
+				r: &release{
+					Name:      "thisRelease",
+					Namespace: "namespace",
+					Enabled:   true,
+				},
+				s: &state{},
+			},
+			want: create,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targetMap = make(map[string]bool)
+
+			for _, target := range tt.targetFlag {
+				targetMap[target] = true
+			}
+			outcome = plan{}
+
+			// Act
+			decide(tt.args.r, tt.args.s)
+			got := outcome.Decisions[0].Type
+			t.Log(outcome.Decisions[0].Description)
+
+			// Assert
+			if got != tt.want {
+				t.Errorf("decide() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// String allows for pretty printing decisionType const
+func (dt decisionType) String() string {
+	switch dt {
+	case create:
+		return "create"
+	case change:
+		return "change"
+	case delete:
+		return "delete"
+	case noop:
+		return "noop"
+	}
+	return "unknown"
+}

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -485,8 +485,14 @@ func cleanUntrackedReleases() {
 	} else {
 		for ns, releases := range toDelete {
 			for r := range releases {
-				logDecision("DECISION: untracked release found: release [ "+r+" ] from Tiller in namespace [ "+ns+" ]. It will be deleted.", -800, delete)
-				deleteUntrackedRelease(r, ns)
+				if len(targetMap) > 0 {
+					if _, ok := targetMap[r]; !ok {
+						logDecision("DECISION: untracked release [ "+r+" ] is ignored by target flag. Skipping.", -800, noop)
+					} else {
+						logDecision("DECISION: untracked release found: release [ "+r+" ] from Tiller in namespace [ "+ns+" ]. It will be deleted.", -800, delete)
+						deleteUntrackedRelease(r, ns)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The new  `-target` flag does not ignore untracked releases, even when specifically stating which release we are targeting.

Releases that are not specified by a  `-target` flag is now also ignored.

I have added tests for the `-target` flag behaviour defined in the `decision_maker.go` file, but I am unfortunately not able to write a test for `-target` flag for untracked releases, in the way the code is structured today.

I was thinking that maybe the `func cleanUntrackedReleases()` in `helm_helper` should actually be a part of the `decide(r,s)` func so that all decisions are made when building the plan?