### PR TITLE
Adding global toggle to be able to disable environment substitution

### DIFF
--- a/docs/cmd_reference.md
+++ b/docs/cmd_reference.md
@@ -62,7 +62,10 @@ This is the list of the available CMD options in Helmsman:
         show verbose execution logs.
 
   `--kubeconfig`
-        path to the kubeconfig file to use for CLI requests
+        path to the kubeconfig file to use for CLI requests.
 
-  `--target` 
-        limit execution to specific app.      
+  `--target`
+        limit execution to specific app.
+
+  `--no-env-subst`
+        turn off environment substitution globally.

--- a/init.go
+++ b/init.go
@@ -58,6 +58,7 @@ func init() {
 	flag.BoolVar(&keepUntrackedReleases, "keep-untracked-releases", false, "keep releases that are managed by Helmsman and are no longer tracked in your desired state.")
 	flag.BoolVar(&showDiff, "show-diff", false, "show helm diff results. Can expose sensitive information.")
 	flag.BoolVar(&suppressDiffSecrets, "suppress-diff-secrets", false, "don't show secrets in helm diff output.")
+	flag.BoolVar(&noEnvSubst, "no-env-subst", false, "turn off environment substitution globally")
 
 	log.SetOutput(os.Stdout)
 

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ var targetMap map[string]bool
 var destroy bool
 var showDiff bool
 var suppressDiffSecrets bool
+var noEnvSubst bool
 
 const tempFilesDir = ".helmsman-tmp"
 const stableHelmRepo = "https://kubernetes-charts.storage.googleapis.com"


### PR DESCRIPTION
After the environment substitution was fixed in a recent version, we've noticed that it breaks some of the existing official Helm charts by replacing `${random_string}` in Helm values to an empty string. This change introduces a new flag to be able to turn this custom behavior globally for those who are not interested in using environment substitution feature in Helmsman.