### PR TITLE
Fix bug with diff-context flag

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -255,7 +255,7 @@ func diffRelease(r *release) string {
 		colorFlag = "--no-color "
 	}
 	if diffContext != -1 {
-		diffContextFlag = "--context " + strconv.Itoa(diffContext)
+		diffContextFlag = "--context " + strconv.Itoa(diffContext) + " "
 	}
 	if suppressDiffSecrets {
 		suppressDiffSecretsFlag = "--suppress-secrets "


### PR DESCRIPTION
diffRelease() expects its flags to end with whitespace, which diffContextFlag does not. This bug prevents the flag from working at all.

A less brittle approach generally would be to pass all flags as separate elements of the Args field, leaving them to be joined by cmd.exec(). This would however result in variable numbers of spaces depending on which flags are enabled.