### PR TITLE
adding --update-deps option for local charts dependency update before use

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -18,6 +18,7 @@ func makePlan(s *state) *plan {
 	buildState()
 
 	for _, r := range s.Apps {
+		checkChartDepUpdate(r)
 		decide(r, s)
 	}
 
@@ -134,8 +135,6 @@ func testRelease(r *release) {
 
 // installRelease creates a Helm command to install a particular release in a particular namespace using a particular Tiller.
 func installRelease(r *release) {
-	checkChartDepUpdate(r)
-
 	cmd := command{
 		Cmd:         "bash",
 		Args:        []string{"-c", helmCommandFromConfig(r) + " install " + r.Chart + " -n " + r.Name + " --namespace " + r.Namespace + getValuesFiles(r) + " --version " + r.Version + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getHelmFlags(r)},
@@ -281,8 +280,6 @@ func diffRelease(r *release) string {
 
 // upgradeRelease upgrades an existing release with the specified values.yaml
 func upgradeRelease(r *release) {
-	checkChartDepUpdate(r)
-
 	cmd := command{
 		Cmd:         "bash",
 		Args:        []string{"-c", helmCommandFromConfig(r) + " upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + " --force " + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getHelmFlags(r)},
@@ -302,8 +299,6 @@ func reInstallRelease(r *release, rs releaseState) {
 		Description: "deleting release [ " + r.Name + " ] from namespace [[ " + r.Namespace + " ]] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 	outcome.addCommand(delCmd, r.Priority, r)
-
-	checkChartDepUpdate(r)
 
 	installCmd := command{
 		Cmd:         "bash",

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -231,8 +231,7 @@ func validateReleaseCharts(apps map[string]*release) (bool, string) {
 			}
 		}
 		if validateCurrentChart {
-			isLocal := filepath.IsAbs(r.Chart)
-			if isLocal {
+			if isLocalChart(r.Chart) {
 				cmd := command{
 					Cmd:         "bash",
 					Args:        []string{"-c", "helm inspect chart '" + r.Chart + "'"},
@@ -554,4 +553,20 @@ func decryptSecret(name string) bool {
 	}
 
 	return true
+}
+
+// updateChartDep updates dependencies for a local chart
+func updateChartDep(chartPath string) (bool, string) {
+	cmd := command{
+		Cmd:         "bash",
+		Args:        []string{"-c", "helm dependency update " + chartPath},
+		Description: "Updateing dependency for local chart " + chartPath,
+	}
+
+	exitCode, err := cmd.exec(debug, verbose)
+
+	if exitCode != 0 {
+		return false, err
+	}
+	return true, ""
 }

--- a/init.go
+++ b/init.go
@@ -60,7 +60,7 @@ func init() {
 	flag.BoolVar(&suppressDiffSecrets, "suppress-diff-secrets", false, "don't show secrets in helm diff output.")
 	flag.IntVar(&diffContext, "diff-context", -1, "number of lines of context to show around changes in helm diff output")
 	flag.BoolVar(&noEnvSubst, "no-env-subst", false, "turn off environment substitution globally")
-
+	flag.BoolVar(&updateDeps, "update-deps", false, "run 'helm dep up' for local chart")
 
 	log.SetOutput(os.Stdout)
 

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ var showDiff bool
 var suppressDiffSecrets bool
 var diffContext int
 var noEnvSubst bool
+var updateDeps bool
 
 const tempFilesDir = ".helmsman-tmp"
 const stableHelmRepo = "https://kubernetes-charts.storage.googleapis.com"

--- a/utils.go
+++ b/utils.go
@@ -514,3 +514,8 @@ func Indent(s, prefix string) string {
 	}
 	return string(res)
 }
+
+// isLocalChart checks if a chart specified in the DSF is a local directory or not
+func isLocalChart(chart string) bool {
+	return filepath.IsAbs(chart)
+}


### PR DESCRIPTION
This implements feature requested in #231 
The new `--update-deps` option will cause helmsman to run `helm dep up` on each local chart (defined as a path in the DSF) before the decision process starts. 

