### PR TITLE
adding --force-upgrades option [ changes default upgrade behaviour]

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -280,9 +280,13 @@ func diffRelease(r *release) string {
 
 // upgradeRelease upgrades an existing release with the specified values.yaml
 func upgradeRelease(r *release) {
+	var force string
+	if forceUpgrades {
+		force = " --force "
+	}
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", helmCommandFromConfig(r) + " upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + " --force " + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getHelmFlags(r)},
+		Args:        []string{"-c", helmCommandFromConfig(r) + " upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + force + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getHelmFlags(r)},
 		Description: "upgrading release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 

--- a/init.go
+++ b/init.go
@@ -60,7 +60,7 @@ func init() {
 	flag.BoolVar(&suppressDiffSecrets, "suppress-diff-secrets", false, "don't show secrets in helm diff output.")
 	flag.IntVar(&diffContext, "diff-context", -1, "number of lines of context to show around changes in helm diff output")
 	flag.BoolVar(&noEnvSubst, "no-env-subst", false, "turn off environment substitution globally")
-
+	flag.BoolVar(&forceUpgrades, "force-upgrades", false, "use --force when upgrading helm releases. May cause resources to be recreated.")
 
 	log.SetOutput(os.Stdout)
 

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ var showDiff bool
 var suppressDiffSecrets bool
 var diffContext int
 var noEnvSubst bool
+var forceUpgrades bool
 
 const tempFilesDir = ".helmsman-tmp"
 const stableHelmRepo = "https://kubernetes-charts.storage.googleapis.com"


### PR DESCRIPTION
This PR fixes #270 by removing the helm `--force` option which has been used by default in helmsman. Now, the `--force` option will be used with helm upgrades only if helmsman's `--force-upgrades` flag is used.