### PR TITLE
Fix for broken link to docs for private helm charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Please make sure the following are installed prior to using `helmsman` as a bina
 - [helm](https://github.com/helm/helm) (for `helmsman` >= 1.6.0, use helm >= 2.10.0. this is due to a dependency bug #87 )
 - [helm-diff](https://github.com/databus23/helm-diff) (`helmsman` >= 1.6.0)
 
-If you use private helm repos, you will need either `helm-gcs` or `helm-s3` plugin or you can use basic auth to authenticate to your repos. See the [docs](https://github.com/Praqma/helmsman/blob/master/docs/how_to/use_private_helm_charts.md) for details.
+If you use private helm repos, you will need either `helm-gcs` or `helm-s3` plugin or you can use basic auth to authenticate to your repos. See the [docs](https://github.com/Praqma/helmsman/blob/master/docs/how_to/helm_repos) for details.
 
 
 Check the [releases page](https://github.com/Praqma/Helmsman/releases) for the different versions.

--- a/docs/how_to/helm_repos/README.md
+++ b/docs/how_to/helm_repos/README.md
@@ -1,0 +1,11 @@
+
+# Defining Helm Repositories
+
+Following list contains guides on how to define helm repositories
+
+- [Using default helm repos](default.md)
+- [Using private repos in Google GCS](gcs.md)
+- [Using private repos in AWS S3](s3.md)
+- [Using private repos with basic auth](basic_auth.md)
+- [Using pre-configured repos](pre_configured.md)
+- [Using local charts](local.md)


### PR DESCRIPTION
The docs link to use_private_helm_charts.md under Install -> From Binary in README.md is broken after commit 11787f3d37adf0255650f5506220fed387734311.

I created a new landing README.md under docs/how-to/helm_repos. This contains the same list of how-to of defining helm repos present in docs/how-to/README.md for helm_repos. Also pointed docs link under Install -> From Binary to this new landing page in docs/how-to/helm_repos.

The newly created landing page will look like https://github.com/amaldevs/helmsman/tree/fix-broken-link/docs/how_to/helm_repos. In code the path is hardcoded to https://github.com/Praqma/helmsman/tree/master/docs/how_to/helm_repos to follow the standard followed across README.md file.