### PR TITLE
Fetch explicit chart version when deciding to upgrade

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -211,6 +211,14 @@ func deleteRelease(r *release, rs releaseState) {
 func inspectUpgradeScenario(r *release, rs releaseState) {
 
 	if r.Namespace == rs.Namespace {
+
+		version, msg := getChartVersion(r)
+		if msg != "" {
+			logError(msg)
+			return
+		}
+		r.Version = version
+
 		if extractChartName(r.Chart) == getReleaseChartName(rs) && r.Version != getReleaseChartVersion(rs) {
 			// upgrade
 			diffRelease(r)

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/Praqma/helmsman/gcs"
-	"github.com/hashicorp/go-version"
 )
 
 var currentState map[string]releaseState
@@ -269,6 +268,29 @@ func validateReleaseCharts(apps map[string]*release) (bool, string) {
 
 	}
 	return true, ""
+}
+
+// getChartVersion fetches the lastest chart version matching the semantic versioning constraints.
+func getChartVersion(r *release) (string, string) {
+	cmd := command{
+		Cmd:         "bash",
+		Args:        []string{"-c", "helm search " + r.Chart + " --version " + strconv.Quote(r.Version)},
+		Description: "getting latest chart version " + r.Chart + "-" + r.Version + "",
+	}
+
+	if exitCode, result := cmd.exec(debug, verbose); exitCode != 0 || strings.Contains(result, "No results found") {
+		return "", "ERROR: chart " + r.Chart + "-" + r.Version + " is specified for " + "but version is not found in the defined repo."
+	} else {
+		versions := strings.Split(result, "\n")
+		if len(versions) < 2 {
+			return "", "ERROR: chart " + r.Chart + "-" + r.Version + " is specified for " + "but version is not found in the defined repo."
+		}
+		fields := strings.Split(versions[1], "\t")
+		if len(fields) != 4 {
+			return "", "ERROR: chart " + r.Chart + "-" + r.Version + " is specified for " + "but version is not found in the defined repo."
+		}
+		return strings.TrimSpace(fields[1]), ""
+	}
 }
 
 // waitForTiller keeps checking if the helm Tiller is ready or not by executing helm list and checking its error (if any)

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Praqma/helmsman/gcs"
+	version "github.com/hashicorp/go-version"
 )
 
 var currentState map[string]releaseState


### PR DESCRIPTION
This is a crude PR for the issue described in https://github.com/Praqma/helmsman/issues/279

Something I noticed is that `helm search` not only includes exact matches, e.g.:
```
helm search stable/elasticsearch              
NAME                            CHART VERSION   APP VERSION     DESCRIPTION                                                 
stable/elasticsearch            1.30.0          6.7.0           Flexible and powerful open source, distributed real-time ...
stable/elasticsearch-curator    2.0.0           5.5.4           A Helm chart for Elasticsearch Curator                      
stable/elasticsearch-exporter   1.7.0           1.0.2           Elasticsearch stats exporter for Prometheus
```
This means that the logic in https://github.com/Praqma/helmsman/blob/master/helm_helpers.go#L263 is not entirely correct as the chart specified could not exist but it could be a substring of another chart.