### PR TITLE
Version should be quoted to support *

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -137,7 +137,7 @@ func testRelease(r *release) {
 func installRelease(r *release) {
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", helmCommandFromConfig(r) + " install " + r.Chart + " -n " + r.Name + " --namespace " + r.Namespace + getValuesFiles(r) + " --version " + r.Version + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getHelmFlags(r)},
+		Args:        []string{"-c", helmCommandFromConfig(r) + " install " + r.Chart + " -n " + r.Name + " --namespace " + r.Namespace + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getHelmFlags(r)},
 		Description: "installing release [ " + r.Name + " ] in namespace [[ " + r.Namespace + " ]] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
 	}
 	outcome.addCommand(cmd, r.Priority, r)


### PR DESCRIPTION
Fixes bug introduced in 'https://github.com/Praqma/helmsman/commit/54d757a2a24ad8e1b18781c64289e9a6e4d56637#diff-4285687681003b9e1299d0581a920915L140'

In `v1.9.1` the following command is generated when installing a chart with `*` as chart version:
```
helm upgrade --install httpbin-default private-repo/default-chart --version "*" --namespace default -f .helmsman-tmp/tmp467875617/dev.yaml --wait --tiller-namespace kube-system --timeout 90 --dry-run --debug
```
Since the above commit, this became:
```
helm install private-repo/default-chart -n httpbin-default --namespace default -f .helmsman-tmp/tmp648299183/dev.yaml --version * --wait --tiller-namespace kube-system --timeout 90 --dry-run --debug
```
The unquoted `*` leads to the following error:
```
Command returned with exit code: . And error message: Error: This command needs 1 argument: chart name
```