### PR TITLE
Added support of running Helmsman on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.world
 *.world1
 helmsman
+helmsman.exe

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,5 +8,6 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64

--- a/decision_maker_test.go
+++ b/decision_maker_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -11,7 +12,7 @@ func Test_getValuesFiles(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want string
+		want []string
 	}{
 		{
 			name: "test case 1",
@@ -29,7 +30,7 @@ func Test_getValuesFiles(t *testing.T) {
 				},
 				//s: st,
 			},
-			want: " -f test_files/values.yaml",
+			want: []string{"-f", "test_files/values.yaml"},
 		},
 		{
 			name: "test case 2",
@@ -47,7 +48,7 @@ func Test_getValuesFiles(t *testing.T) {
 				},
 				//s: st,
 			},
-			want: " -f test_files/values.yaml",
+			want: []string{"-f", "test_files/values.yaml"},
 		},
 		{
 			name: "test case 1",
@@ -65,12 +66,12 @@ func Test_getValuesFiles(t *testing.T) {
 				},
 				//s: st,
 			},
-			want: " -f test_files/values.yaml -f test_files/values2.yaml",
+			want: []string{"-f", "test_files/values.yaml", "-f", "test_files/values2.yaml"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getValuesFiles(tt.args.r); got != tt.want {
+			if got := getValuesFiles(tt.args.r); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getValuesFiles() = %v, want %v", got, tt.want)
 			}
 		})

--- a/helm_helpers_test.go
+++ b/helm_helpers_test.go
@@ -9,11 +9,11 @@ import (
 
 func setupTestCase(t *testing.T) func(t *testing.T) {
 	t.Log("setup test case")
-	os.MkdirAll("/tmp/helmsman-tests/myapp", os.ModePerm)
-	os.MkdirAll("/tmp/helmsman-tests/dir-with space/myapp", os.ModePerm)
+	os.MkdirAll(os.TempDir()+"/helmsman-tests/myapp", os.ModePerm)
+	os.MkdirAll(os.TempDir()+"/helmsman-tests/dir-with space/myapp", os.ModePerm)
 	cmd := command{
-		Cmd:         "bash",
-		Args:        []string{"-c", "helm create  '/tmp/helmsman-tests/dir-with space/myapp'"},
+		Cmd:         "helm",
+		Args:        []string{"create", os.TempDir() + "/helmsman-tests/dir-with space/myapp"},
 		Description: "creating an empty local chart directory",
 	}
 	if exitCode, msg := cmd.exec(debug, verbose); exitCode != 0 {
@@ -30,13 +30,13 @@ func Test_validateReleaseCharts(t *testing.T) {
 		apps map[string]*release
 	}
 	tests := []struct {
-		name string
+		name       string
 		targetFlag []string
-		args args
-		want bool
+		args       args
+		want       bool
 	}{
 		{
-			name: "test case 1: valid local path with no chart",
+			name:       "test case 1: valid local path with no chart",
 			targetFlag: []string{},
 			args: args{
 				apps: map[string]*release{
@@ -45,7 +45,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 						Description:     "",
 						Namespace:       "",
 						Enabled:         true,
-						Chart:           "/tmp/helmsman-tests/myapp",
+						Chart:           os.TempDir() + "/helmsman-tests/myapp",
 						Version:         "",
 						ValuesFile:      "",
 						ValuesFiles:     []string{},
@@ -67,7 +67,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 			},
 			want: false,
 		}, {
-			name: "test case 2: invalid local path",
+			name:       "test case 2: invalid local path",
 			targetFlag: []string{},
 			args: args{
 				apps: map[string]*release{
@@ -76,7 +76,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 						Description:     "",
 						Namespace:       "",
 						Enabled:         true,
-						Chart:           "/tmp/does-not-exist/myapp",
+						Chart:           os.TempDir() + "/does-not-exist/myapp",
 						Version:         "",
 						ValuesFile:      "",
 						ValuesFiles:     []string{},
@@ -98,7 +98,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 			},
 			want: false,
 		}, {
-			name: "test case 3: valid chart local path with whitespace",
+			name:       "test case 3: valid chart local path with whitespace",
 			targetFlag: []string{},
 			args: args{
 				apps: map[string]*release{
@@ -107,7 +107,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 						Description:     "",
 						Namespace:       "",
 						Enabled:         true,
-						Chart:           "/tmp/helmsman-tests/dir-with space/myapp",
+						Chart:           os.TempDir() + "/helmsman-tests/dir-with space/myapp",
 						Version:         "0.1.0",
 						ValuesFile:      "",
 						ValuesFiles:     []string{},
@@ -129,7 +129,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 			},
 			want: true,
 		}, {
-			name: "test case 4: valid chart from repo",
+			name:       "test case 4: valid chart from repo",
 			targetFlag: []string{},
 			args: args{
 				apps: map[string]*release{
@@ -160,7 +160,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 			},
 			want: true,
 		}, {
-			name: "test case 5: invalid local path for chart ignored with -target flag, while other app was targeted",
+			name:       "test case 5: invalid local path for chart ignored with -target flag, while other app was targeted",
 			targetFlag: []string{"notThisOne"},
 			args: args{
 				apps: map[string]*release{
@@ -169,7 +169,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 						Description:     "",
 						Namespace:       "",
 						Enabled:         true,
-						Chart:           "/tmp/does-not-exist/myapp",
+						Chart:           os.TempDir() + "/does-not-exist/myapp",
 						Version:         "",
 						ValuesFile:      "",
 						ValuesFiles:     []string{},
@@ -191,7 +191,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 			},
 			want: true,
 		}, {
-			name: "test case 6: invalid local path for chart included with -target flag",
+			name:       "test case 6: invalid local path for chart included with -target flag",
 			targetFlag: []string{"app"},
 			args: args{
 				apps: map[string]*release{
@@ -200,7 +200,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 						Description:     "",
 						Namespace:       "",
 						Enabled:         true,
-						Chart:           "/tmp/does-not-exist/myapp",
+						Chart:           os.TempDir() + "/does-not-exist/myapp",
 						Version:         "",
 						ValuesFile:      "",
 						ValuesFiles:     []string{},
@@ -234,7 +234,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 				targetMap[target] = true
 			}
 			if got, msg := validateReleaseCharts(tt.args.apps); got != tt.want {
-				t.Errorf("getReleaseChartName() = %v, want %v , msg: %v", got, tt.want, msg)
+				t.Errorf("validateReleaseCharts() = %v, want %v , msg: %v", got, tt.want, msg)
 			}
 		})
 	}
@@ -335,7 +335,7 @@ func Test_getReleaseChartVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Log(tt.want)
 			if got := getReleaseChartVersion(tt.args.r); got != tt.want {
-				t.Errorf("getReleaseChartName() = %v, want %v", got, tt.want)
+				t.Errorf("getReleaseChartVersion() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -344,7 +344,6 @@ func Test_getReleaseChartVersion(t *testing.T) {
 
 func Test_getChartVersion(t *testing.T) {
 	// version string = the first semver-valid string after the last hypen in the chart string.
-
 	type args struct {
 		r *release
 	}

--- a/init.go
+++ b/init.go
@@ -212,8 +212,8 @@ func init() {
 // It takes as input the tool's command to check if it is recognizable or not. e.g. helm or kubectl
 func toolExists(tool string) bool {
 	cmd := command{
-		Cmd:         "bash",
-		Args:        []string{"-c", tool},
+		Cmd:         tool,
+		Args:        []string{},
 		Description: "validating that " + tool + " is installed.",
 	}
 
@@ -230,8 +230,8 @@ func toolExists(tool string) bool {
 // It takes as input the plugin's name to check if it is recognizable or not. e.g. diff
 func helmPluginExists(plugin string) bool {
 	cmd := command{
-		Cmd:         "bash",
-		Args:        []string{"-c", "helm plugin list"},
+		Cmd:         "helm",
+		Args:        []string{"plugin", "list"},
 		Description: "validating that " + plugin + " is installed.",
 	}
 

--- a/init_test.go
+++ b/init_test.go
@@ -24,9 +24,9 @@ func Test_toolExists(t *testing.T) {
 			},
 			want: true,
 		}, {
-			name: "test case 3 -- checking ipconfig exists.",
+			name: "test case 3 -- checking nonExistingTool exists.",
 			args: args{
-				tool: "ipconfig",
+				tool: "nonExistingTool",
 			},
 			want: false,
 		},

--- a/release.go
+++ b/release.go
@@ -64,14 +64,15 @@ func validateRelease(appLabel string, r *release, names map[string]map[string]bo
 		return false, "release " + r.Name + " is using namespace [ " + r.Namespace + " ] which is not defined in the Namespaces section of your desired state file." +
 			" Release [ " + r.Name + " ] can't be installed in that Namespace until its defined."
 	}
-	if r.Chart == "" || !strings.ContainsAny(r.Chart, "/") {
+	_, err := os.Stat(r.Chart)
+	if r.Chart == "" || os.IsNotExist(err) && !strings.ContainsAny(r.Chart, "/") {
 		return false, "chart can't be empty and must be of the format: repo/chart."
 	}
 	if r.Version == "" {
 		return false, "version can't be empty."
 	}
 
-	_, err := os.Stat(r.ValuesFile)
+	_, err = os.Stat(r.ValuesFile)
 	if r.ValuesFile != "" && (!isOfType(r.ValuesFile, []string{".yaml", ".yml", ".json"}) || err != nil) {
 		return false, fmt.Sprintf("valuesFile must be a valid relative (from dsf file) file path for a yaml file, or can be left empty (provided path resolved to %q).", r.ValuesFile)
 	} else if r.ValuesFile != "" && len(r.ValuesFiles) > 0 {

--- a/utils.go
+++ b/utils.go
@@ -548,3 +548,12 @@ func generateDecisionMessage(r *release, message string, isTillerAware bool) str
 	}
 	return baseMessage
 }
+
+// concat appends all slices to a single slice
+func concat(slices ...[]string) []string {
+	slice := []string{}
+	for _, item := range slices {
+		slice = append(slice, item...)
+	}
+	return slice
+}


### PR DESCRIPTION
Any execution of a command using bash with the command parameter has been replaced with just the expected command executable (helm and kubectl). And instead of building the arguments as a single string, they are now built using string arrays. This solves the "quoting" problem, that is there when using a single string with all arguments. For example, before this change, a path had to be quoted on Windows to work. By just building string arrays with all the arguments, this problem is solved by Go' os/exec package.

It also solves the problem of using a password protected Helm repo, where the username contains a '$' (for example Harbor creates robot accounts with this). This could be escaped using '$$', but then it still was being interpreted by bash as an environment variable. This could have been solved by adding quotes around in the old solution, but it is just simpler to just use the "native" string array arguments approach as described above. And still if the environment variable was intended as input, then it is already applied by the "substituteEnv" functionality.