### PR TITLE
fix: getChartVersion is skipped when local charts

### DIFF
--- a/decision_maker_test.go
+++ b/decision_maker_test.go
@@ -77,6 +77,51 @@ func Test_getValuesFiles(t *testing.T) {
 	}
 }
 
+func Test_inspectUpgradeScenario(t *testing.T){
+	type args struct {
+		r *release
+		s releaseState
+	}
+	tests := []struct {
+		name       string
+		args       args
+		want       decisionType
+	}{
+		{
+			name:       "inspectUpgradeScenario() - local chart with different chart name should change",
+			args: args{
+				r: &release{
+					Name:      "release1",
+					Namespace: "namespace",
+					Version: "1.0.0",
+					Chart: "/local/charts",
+					Enabled:   true,
+				},
+				s: releaseState{
+					Namespace: "namespace",
+					Chart: "chart-1.0.0",
+				},
+			},
+			want: change,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outcome = plan{}
+
+			// Act
+			inspectUpgradeScenario(tt.args.r, tt.args.s)
+			got := outcome.Decisions[0].Type
+			t.Log(outcome.Decisions[0].Description)
+
+			// Assert
+			if got != tt.want {
+				t.Errorf("decide() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_decide(t *testing.T) {
 	type args struct {
 		r *release

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -272,7 +272,11 @@ func validateReleaseCharts(apps map[string]*release) (bool, string) {
 }
 
 // getChartVersion fetches the lastest chart version matching the semantic versioning constraints.
+// If chart is local, returns the given release version
 func getChartVersion(r *release) (string, string) {
+	if isLocalChart(r.Chart) {
+		return r.Version, ""
+	}
 	cmd := command{
 		Cmd:         "bash",
 		Args:        []string{"-c", "helm search " + r.Chart + " --version " + strconv.Quote(r.Version)},

--- a/helm_helpers_test.go
+++ b/helm_helpers_test.go
@@ -339,3 +339,53 @@ func Test_getReleaseChartVersion(t *testing.T) {
 		})
 	}
 }
+
+
+func Test_getChartVersion(t *testing.T) {
+	// version string = the first semver-valid string after the last hypen in the chart string.
+
+	type args struct {
+		r *release
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "getChartVersion - local chart should return given release version",
+			args: args{
+				r: &release{
+					Name:      "release1",
+					Namespace: "namespace",
+					Version: "1.0.0",
+					Chart: "/local/charts",
+					Enabled:   true,
+				},
+			},
+			want: "1.0.0",
+		},
+		{
+			name: "getChartVersion - unknown chart should error",
+			args: args{
+				r: &release{
+					Name:      "release1",
+					Namespace: "namespace",
+					Version: "1.0.0",
+					Chart: "random-chart-name-1f8147",
+					Enabled:   true,
+				},
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log(tt.want)
+			got, _ := getChartVersion(tt.args.r);
+			if  got != tt.want {
+				t.Errorf("getChartVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR make sure that when we get the chart version with getChartVersion, we simply return the given release version. Maybe we should read the `Chart.yaml` instead but this is a simple and fast fix.

Also, it adds test for `helm_helpers.go -> getChartVersion` and `decision_maker.go -> inspectUpgradeScenario` in order to make sure that local chart works correctly.

Closes #286 