### PR TITLE
Decision logging fixed for tillerless; add decisionType ignored with gray color

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -31,7 +31,7 @@ func decide(r *release, s *state) {
 	// check for presence in defined targets
 	if len(targetMap) > 0 {
 		if _, ok := targetMap[r.Name]; !ok {
-			logDecision("DECISION: release [ "+r.Name+" ] is ignored by target flag. Skipping.", r.Priority, noop)
+			logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is ignored by target flag. Skipping.", false), r.Priority, noop)
 			return
 		}
 	}
@@ -55,11 +55,11 @@ func decide(r *release, s *state) {
 				deleteRelease(r, rs)
 
 			} else {
-				logDecision("DECISION: release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is PROTECTED. Operations are not allowed on this release until "+
-					"you remove its protection.", r.Priority, noop)
+				logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is PROTECTED. Operations are not allowed on this release until "+
+					"you remove its protection.", false), r.Priority, noop)
 			}
 		} else {
-			logDecision("DECISION: release [ "+r.Name+" ] is set to be disabled but is not yet deployed. Skipping.", r.Priority, noop)
+			logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is set to be disabled but is not yet deployed. Skipping.", false), r.Priority, noop)
 		}
 
 	} else { // check for install/upgrade/rollback
@@ -68,8 +68,8 @@ func decide(r *release, s *state) {
 				inspectUpgradeScenario(r, rs) // upgrade or move
 
 			} else {
-				logDecision("DECISION: release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is PROTECTED. Operations are not allowed on this release until "+
-					"you remove its protection.", r.Priority, noop)
+				logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is PROTECTED. Operations are not allowed on this release until "+
+					"you remove its protection.", false), r.Priority, noop)
 			}
 
 		} else if ok, rs := helmReleaseExists(r, "deleted"); ok {
@@ -78,20 +78,20 @@ func decide(r *release, s *state) {
 				rollbackRelease(r, rs) // rollback
 
 			} else {
-				logDecision("DECISION: release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is PROTECTED. Operations are not allowed on this release until "+
-					"you remove its protection.", r.Priority, noop)
+				logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is PROTECTED. Operations are not allowed on this release until "+
+					"you remove its protection.", false), r.Priority, noop)
 			}
 
 		} else if ok, rs := helmReleaseExists(r, "failed"); ok {
 
 			if !isProtected(r, rs) {
 
-				logDecision("DECISION: release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is in FAILED state. I will upgrade it for you. Hope it gets fixed!", r.Priority, change)
+				logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is in FAILED state. I will upgrade it for you. Hope it gets fixed!", false), r.Priority, change)
 				upgradeRelease(r)
 
 			} else {
-				logDecision("DECISION: release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is PROTECTED. Operations are not allowed on this release until "+
-					"you remove its protection.", r.Priority, noop)
+				logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is PROTECTED. Operations are not allowed on this release until "+
+					"you remove its protection.", false), r.Priority, noop)
 			}
 		} else {
 
@@ -126,11 +126,10 @@ func testRelease(r *release) {
 	cmd := command{
 		Cmd:         "bash",
 		Args:        []string{"-c", helmCommandFromConfig(r) + " test " + r.Name + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r)},
-		Description: "running tests for release [ " + r.Name + " ]",
+		Description: generateCmdDescription(r, "running tests for"),
 	}
 	outcome.addCommand(cmd, r.Priority, r)
-	logDecision("DECISION: release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is required to be tested when installed. Got it!", r.Priority, noop)
-
+	logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is required to be tested when installed. Got it!", false), r.Priority, noop)
 }
 
 // installRelease creates a Helm command to install a particular release in a particular namespace using a particular Tiller.
@@ -138,11 +137,10 @@ func installRelease(r *release) {
 	cmd := command{
 		Cmd:         "bash",
 		Args:        []string{"-c", helmCommandFromConfig(r) + " install " + r.Chart + " -n " + r.Name + " --namespace " + r.Namespace + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getHelmFlags(r)},
-		Description: "installing release [ " + r.Name + " ] in namespace [[ " + r.Namespace + " ]] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
+		Description: generateCmdDescription(r, "installing"),
 	}
 	outcome.addCommand(cmd, r.Priority, r)
-	logDecision("DECISION: release [ "+r.Name+" ] is not installed. Will install it in namespace [[ "+
-		r.Namespace+" ]] using Tiller in [ "+getDesiredTillerNamespace(r)+" ]", r.Priority, create)
+	logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is not installed. Will install it in namespace [[ "+ r.Namespace+" ]]", true), r.Priority, create)
 
 	if r.Test {
 		testRelease(r)
@@ -159,21 +157,19 @@ func rollbackRelease(r *release, rs releaseState) {
 		cmd := command{
 			Cmd:         "bash",
 			Args:        []string{"-c", helmCommandFromConfig(r) + " rollback " + r.Name + " " + getReleaseRevision(rs) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getTimeout(r) + getNoHooks(r) + getDryRunFlags()},
-			Description: "rolling back release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
+			Description: generateCmdDescription(r, "rolling back"),
 		}
 		outcome.addCommand(cmd, r.Priority, r)
 		upgradeRelease(r) // this is to reflect any changes in values file(s)
-		logDecision("DECISION: release [ "+r.Name+" ] is currently deleted and is desired to be rolledback to "+
-			"namespace [[ "+r.Namespace+" ]] . It will also be upgraded in case values have changed.", r.Priority, change)
-
+		logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is currently deleted and is desired to be rolledback to "+
+			"namespace [[ "+r.Namespace+" ]] . It will also be upgraded in case values have changed.", false), r.Priority, create)
 	} else {
-
 		reInstallRelease(r, rs)
-		logDecision("DECISION: release [ "+r.Name+" ] is deleted BUT from namespace [[ "+rs.Namespace+
-			" ]]. Will purge delete it from there and install it in namespace [[ "+r.Namespace+" ]]", r.Priority, change)
-		logDecision("WARNING: rolling back release [ "+r.Name+" ] from [[ "+rs.Namespace+" ]] to [[ "+r.Namespace+
+		logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is deleted BUT from namespace [[ "+rs.Namespace+
+			" ]]. Will purge delete it from there and install it in namespace [[ "+r.Namespace+" ]]", false), r.Priority, create)
+		logDecision(generateDecisionMessage(r, "WARNING: rolling back release [ "+r.Name+" ] from [[ "+rs.Namespace+" ]] to [[ "+r.Namespace+
 			" ]] might not correctly connect to existing volumes. Check https://github.com/Praqma/helmsman/blob/master/docs/how_to/move_charts_across_namespaces.md"+
-			" for details if this release uses PV and PVC.", r.Priority, change)
+			" for details if this release uses PV and PVC.", false), r.Priority, create)
 
 	}
 }
@@ -195,10 +191,10 @@ func deleteRelease(r *release, rs releaseState) {
 	cmd := command{
 		Cmd:         "bash",
 		Args:        []string{"-c", helmCommandFromConfig(r) + " delete " + p + " " + r.Name + getCurrentTillerNamespaceFlag(rs) + getTLSFlags(r) + getDryRunFlags()},
-		Description: "deleting release [ " + r.Name + " ] from namespace [[ " + r.Namespace + " ]] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
+		Description: generateCmdDescription(r, "deleting"),
 	}
 	outcome.addCommand(cmd, priority, r)
-	logDecision("DECISION: release [ "+r.Name+" ] is desired to be deleted "+purgeDesc+". Planning this for you!", priority, delete)
+	logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is desired to be deleted "+purgeDesc+". Planning this for you!", false), r.Priority, delete)
 }
 
 // inspectUpgradeScenario evaluates if a release should be upgraded.
@@ -223,32 +219,31 @@ func inspectUpgradeScenario(r *release, rs releaseState) {
 			// upgrade
 			diffRelease(r)
 			upgradeRelease(r)
-			logDecision("DECISION: release [ "+r.Name+" ] is desired to be upgraded. Planning this for you!", r.Priority, change)
+			logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is desired to be upgraded. Planning this for you!", false), r.Priority, change)
 
 		} else if extractChartName(r.Chart) != getReleaseChartName(rs) {
 			reInstallRelease(r, rs)
-			logDecision("DECISION: release [ "+r.Name+" ] is desired to use a new Chart [ "+r.Chart+
+			logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is desired to use a new Chart [ "+r.Chart+
 				" ]. I am planning a purge delete of the current release and will install it with the new chart in namespace [[ "+
-				r.Namespace+" ]]", r.Priority, change)
-
+				r.Namespace+" ]]", false), r.Priority, change)
 		} else {
 			if diff := diffRelease(r); diff != "" {
 				upgradeRelease(r)
-				logDecision("DECISION: release [ "+r.Name+" ] is currently enabled and have some changed parameters. "+
-					"I will upgrade it!", r.Priority, change)
+				logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is currently enabled and have some changed parameters. "+
+					"I will upgrade it!", false), r.Priority, change)
 			} else {
-				logDecision("DECISION: release [ "+r.Name+" ] is desired to be enabled and is currently enabled. "+
-					"Nothing to do here!", r.Priority, noop)
+				logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is desired to be enabled and is currently enabled. "+
+					"Nothing to do here!", false), r.Priority, noop)
 			}
 		}
 	} else {
 		reInstallRelease(r, rs)
-		logDecision("DECISION: release [ "+r.Name+" ] is desired to be enabled in a new namespace [[ "+r.Namespace+
+		logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is desired to be enabled in a new namespace [[ "+r.Namespace+
 			" ]]. I am planning a purge delete of the current release from namespace [[ "+rs.Namespace+" ]] "+
-			"and will install it for you in namespace [[ "+r.Namespace+" ]]", r.Priority, change)
-		logDecision("WARNING: moving release [ "+r.Name+" ] from [[ "+rs.Namespace+" ]] to [[ "+r.Namespace+
+			"and will install it for you in namespace [[ "+r.Namespace+" ]]", false), r.Priority, change)
+		logDecision(generateDecisionMessage(r, "WARNING: moving release [ "+r.Name+" ] from [[ "+rs.Namespace+" ]] to [[ "+r.Namespace+
 			" ]] might not correctly connect to existing volumes. Check https://github.com/Praqma/helmsman/blob/master/docs/how_to/move_charts_across_namespaces.md"+
-			" for details if this release uses PV and PVC.", r.Priority, change)
+			" for details if this release uses PV and PVC.", false), r.Priority, change)
 	}
 }
 
@@ -272,7 +267,7 @@ func diffRelease(r *release) string {
 	cmd := command{
 		Cmd:         "bash",
 		Args:        []string{"-c", helmCommandFromConfig(r) + " diff " + colorFlag + diffContextFlag + suppressDiffSecretsFlag + "upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + " " + getSetValues(r) + getSetStringValues(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r)},
-		Description: "diffing release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
+		Description: generateCmdDescription(r, "diffing"),
 	}
 
 	if exitCode, msg = cmd.exec(debug, verbose); exitCode != 0 {
@@ -295,7 +290,7 @@ func upgradeRelease(r *release) {
 	cmd := command{
 		Cmd:         "bash",
 		Args:        []string{"-c", helmCommandFromConfig(r) + " upgrade " + r.Name + " " + r.Chart + getValuesFiles(r) + " --version " + strconv.Quote(r.Version) + force + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getHelmFlags(r)},
-		Description: "upgrading release [ " + r.Name + " ] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
+		Description: generateCmdDescription(r, "upgrading"),
 	}
 
 	outcome.addCommand(cmd, r.Priority, r)
@@ -308,14 +303,14 @@ func reInstallRelease(r *release, rs releaseState) {
 	delCmd := command{
 		Cmd:         "bash",
 		Args:        []string{"-c", helmCommandFromConfig(r) + " delete --purge " + r.Name + getCurrentTillerNamespaceFlag(rs) + getTLSFlags(r) + getDryRunFlags()},
-		Description: "deleting release [ " + r.Name + " ] from namespace [[ " + r.Namespace + " ]] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
+		Description: generateCmdDescription(r, "deleting"),
 	}
 	outcome.addCommand(delCmd, r.Priority, r)
 
 	installCmd := command{
 		Cmd:         "bash",
 		Args:        []string{"-c", helmCommandFromConfig(r) + " install " + r.Chart + " --version " + r.Version + " -n " + r.Name + " --namespace " + r.Namespace + getValuesFiles(r) + getSetValues(r) + getSetStringValues(r) + getWait(r) + getDesiredTillerNamespaceFlag(r) + getTLSFlags(r) + getHelmFlags(r)},
-		Description: "installing release [ " + r.Name + " ] in namespace [[ " + r.Namespace + " ]] using Tiller in [ " + getDesiredTillerNamespace(r) + " ]",
+		Description: generateCmdDescription(r, "installing"),
 	}
 	outcome.addCommand(installCmd, r.Priority, r)
 }

--- a/decision_maker.go
+++ b/decision_maker.go
@@ -31,7 +31,7 @@ func decide(r *release, s *state) {
 	// check for presence in defined targets
 	if len(targetMap) > 0 {
 		if _, ok := targetMap[r.Name]; !ok {
-			logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is ignored by target flag. Skipping.", false), r.Priority, noop)
+			logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is ignored by target flag. Skipping.", false), r.Priority, ignored)
 			return
 		}
 	}

--- a/decision_maker_test.go
+++ b/decision_maker_test.go
@@ -144,7 +144,7 @@ func Test_decide(t *testing.T) {
 				},
 				s: &state{},
 			},
-			want: noop,
+			want: ignored,
 		},
 		{
 			name:       "decide() - targetMap does not contain this service - skip",
@@ -157,7 +157,7 @@ func Test_decide(t *testing.T) {
 				},
 				s: &state{},
 			},
-			want: noop,
+			want: ignored,
 		},
 		{
 			name:       "decide() - targetMap is empty - will install",

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -562,19 +562,19 @@ func initHelm() (bool, string) {
 // NOTE: Untracked releases don't benefit from either namespace or application protection.
 // NOTE: Removing/Commenting out an app from the desired state makes it untracked.
 func cleanUntrackedReleases() {
-	toDelete := make(map[string]map[string]bool)
+	toDelete := make(map[string]map[*release]bool)
 	log.Println("INFO: checking if any Helmsman managed releases are no longer tracked by your desired state ...")
 	for ns, releases := range getHelmsmanReleases() {
 		for r := range releases {
 			tracked := false
 			for _, app := range s.Apps {
-				if app.Name == r && getDesiredTillerNamespace(app) == ns {
+				if app.Name == r.Name && getDesiredTillerNamespace(app) == ns {
 					tracked = true
 				}
 			}
 			if !tracked {
 				if _, ok := toDelete[ns]; !ok {
-					toDelete[ns] = make(map[string]bool)
+					toDelete[ns] = make(map[*release]bool)
 				}
 				toDelete[ns][r] = true
 			}
@@ -586,13 +586,12 @@ func cleanUntrackedReleases() {
 	} else {
 		for ns, releases := range toDelete {
 			for r := range releases {
-				if len(targetMap) > 0 {
-					if _, ok := targetMap[r]; !ok {
-						logDecision("DECISION: untracked release [ "+r+" ] is ignored by target flag. Skipping.", -800, noop)
-					} else {
-						logDecision("DECISION: untracked release found: release [ "+r+" ] from Tiller in namespace [ "+ns+" ]. It will be deleted.", -800, delete)
-						deleteUntrackedRelease(r, ns)
-					}
+				_, inTarget := targetMap[r.Name]
+				if len(targetMap) > 0 && inTarget {
+					logDecision(generateDecisionMessage(r, "untracked release [ "+r.Name+" ] is ignored by target flag. Skipping.", false), -800, noop)
+				} else {
+					logDecision(generateDecisionMessage(r, "untracked release found: release [ "+r.Name+" ]. It will be deleted", true), -800, delete)
+					deleteUntrackedRelease(r.Name, ns)
 				}
 			}
 		}
@@ -611,7 +610,8 @@ func deleteUntrackedRelease(release string, tillerNamespace string) {
 	cmd := command{
 		Cmd:         "bash",
 		Args:        []string{"-c", helmCommand(tillerNamespace) + " delete --purge " + release + " --tiller-namespace " + tillerNamespace + tls + getDryRunFlags()},
-		Description: "deleting untracked release [ " + release + " ] from Tiller in namespace [[ " + tillerNamespace + " ]]",
+		//Description: generateCmdDescription(release, "deleting untracked"),
+		Description: "x",
 	}
 
 	outcome.addCommand(cmd, -800, nil)

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -586,9 +586,10 @@ func cleanUntrackedReleases() {
 	} else {
 		for ns, releases := range toDelete {
 			for r := range releases {
-				_, inTarget := targetMap[r.Name]
-				if len(targetMap) > 0 && inTarget {
-					logDecision(generateDecisionMessage(r, "untracked release [ "+r.Name+" ] is ignored by target flag. Skipping.", false), -800, noop)
+				if len(targetMap) > 0 {
+					if _, inTarget := targetMap[r.Name]; !inTarget {
+						logDecision(generateDecisionMessage(r, "untracked release [ "+r.Name+" ] is ignored by target flag. Skipping.", false), -800, ignored)
+					}
 				} else {
 					logDecision(generateDecisionMessage(r, "untracked release found: release [ "+r.Name+" ]. It will be deleted", true), -800, delete)
 					deleteUntrackedRelease(r.Name, ns)

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -592,7 +592,7 @@ func cleanUntrackedReleases() {
 					}
 				} else {
 					logDecision(generateDecisionMessage(r, "untracked release found: release [ "+r.Name+" ]. It will be deleted", true), -800, delete)
-					deleteUntrackedRelease(r.Name, ns)
+					deleteUntrackedRelease(r, ns)
 				}
 			}
 		}
@@ -600,7 +600,7 @@ func cleanUntrackedReleases() {
 }
 
 // deleteUntrackedRelease creates the helm command to purge delete an untracked release
-func deleteUntrackedRelease(release string, tillerNamespace string) {
+func deleteUntrackedRelease(release *release, tillerNamespace string) {
 
 	tls := ""
 	ns := s.Namespaces[tillerNamespace]
@@ -610,9 +610,8 @@ func deleteUntrackedRelease(release string, tillerNamespace string) {
 	}
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", helmCommand(tillerNamespace) + " delete --purge " + release + " --tiller-namespace " + tillerNamespace + tls + getDryRunFlags()},
-		//Description: generateCmdDescription(release, "deleting untracked"),
-		Description: "x",
+		Args:        []string{"-c", helmCommand(tillerNamespace) + " delete --purge " + release.Name + " --tiller-namespace " + tillerNamespace + tls + getDryRunFlags()},
+		Description: generateCmdDescription(release, "deleting untracked"),
 	}
 
 	outcome.addCommand(cmd, -800, nil)

--- a/kube_helpers.go
+++ b/kube_helpers.go
@@ -92,8 +92,8 @@ func createNamespace(ns string) {
 		Args:        []string{"-c", "kubectl create namespace " + ns},
 		Description: "creating namespace  " + ns,
 	}
-
-	if exitCode, _ := cmd.exec(debug, verbose); exitCode != 0 {
+	exitCode, _ := cmd.exec(debug, verbose)
+	if exitCode != 0 && verbose {
 		log.Println("WARN: I could not create namespace [ " +
 			ns + " ]. It already exists. I am skipping this.")
 	}
@@ -108,7 +108,8 @@ func labelNamespace(ns string, labels map[string]string) {
 			Description: "labeling namespace  " + ns,
 		}
 
-		if exitCode, _ := cmd.exec(debug, verbose); exitCode != 0 {
+		exitCode, _ := cmd.exec(debug, verbose)
+		if exitCode != 0 && verbose {
 			log.Println("WARN: I could not label namespace [ " + ns + " with " + k + "=" + v +
 				" ]. It already exists. I am skipping this.")
 		}
@@ -124,7 +125,8 @@ func annotateNamespace(ns string, labels map[string]string) {
 			Description: "annotating namespace  " + ns,
 		}
 
-		if exitCode, _ := cmd.exec(debug, verbose); exitCode != 0 {
+		exitCode, _ := cmd.exec(debug, verbose)
+		if exitCode != 0 && verbose {
 			log.Println("WARN: I could not annotate namespace [ " + ns + " with " + k + "=" + v +
 				" ]. It already exists. I am skipping this.")
 		}
@@ -437,9 +439,9 @@ func labelResource(r *release) {
 // getHelmsmanReleases returns a map of all releases that are labeled with "MANAGED-BY=HELMSMAN"
 // The releases are categorized by the namespaces in which their Tiller is running
 // The returned map format is: map[<Tiller namespace>:map[<releases managed by Helmsman and deployed using this Tiller>:true]]
-func getHelmsmanReleases() map[string]map[string]bool {
+func getHelmsmanReleases() map[string]map[*release]bool {
 	var lines []string
-	releases := make(map[string]map[string]bool)
+	releases := make(map[string]map[*release]bool)
 	storageBackend := "configmap"
 
 	if s.Settings.StorageBackend == "secret" {
@@ -481,9 +483,13 @@ func getHelmsmanReleases() map[string]map[string]bool {
 			} else {
 				fields := strings.Fields(lines[i])
 				if _, ok := releases[ns]; !ok {
-					releases[ns] = make(map[string]bool)
+					releases[ns] = make(map[*release]bool)
 				}
-				releases[ns][fields[0][0:strings.LastIndex(fields[0], ".v")]] = true
+				for _, r := range s.Apps {
+					if r.Name == fields[0][0:strings.LastIndex(fields[0], ".v")] {
+						releases[ns][r] = true
+					}
+				}
 			}
 		}
 	}

--- a/kube_helpers.go
+++ b/kube_helpers.go
@@ -451,7 +451,7 @@ func getHelmsmanReleases() map[string]map[*release]bool {
 	namespaces := make([]string, len(s.Namespaces))
 	i := 0
 	for s, v := range s.Namespaces {
-		if v.InstallTiller || v.UseTiller {
+		if v.InstallTiller || v.UseTiller || settings.Tillerless {
 			namespaces[i] = s
 			i++
 		}

--- a/plan.go
+++ b/plan.go
@@ -20,13 +20,15 @@ const (
 	change
 	delete
 	noop
+	ignored
 )
 
 var decisionColor = map[decisionType]aurora.Color{
-	create: aurora.BlueFg,
-	change: aurora.BrownFg,
-	delete: aurora.RedFg,
-	noop:   aurora.GreenFg,
+	create:  aurora.BlueFg,
+	change:  aurora.BrownFg,
+	delete:  aurora.RedFg,
+	noop:    aurora.GreenFg,
+	ignored: aurora.GrayFg,
 }
 
 // orderedDecision type representing a Decision and it's priority weight

--- a/plan.go
+++ b/plan.go
@@ -92,8 +92,7 @@ func (p plan) execPlan() {
 	}
 
 	for _, cmd := range p.Commands {
-		log.Println("INFO: start applying [ " + cmd.targetRelease.Name + " ] " +
-			"in namespace [ " + cmd.targetRelease.Namespace + " ] ")
+		log.Println("INFO: " + cmd.Command.Description)
 		if exitCode, msg := cmd.Command.exec(debug, verbose); exitCode != 0 {
 			var errorMsg string
 			if errorMsg = msg; !verbose {
@@ -105,8 +104,7 @@ func (p plan) execPlan() {
 			if cmd.targetRelease != nil && !dryRun {
 				labelResource(cmd.targetRelease)
 			}
-			log.Println("INFO: finished applying [ " + cmd.targetRelease.Name + " ] " +
-				"in namespace [ " + cmd.targetRelease.Namespace + " ] ")
+			log.Println("INFO: finished " + cmd.Command.Description)
 			if _, err := url.ParseRequestURI(s.Settings.SlackWebhook); err == nil {
 				notifySlack(cmd.Command.Description+" ... SUCCESS!", s.Settings.SlackWebhook, false, true)
 			}

--- a/state.go
+++ b/state.go
@@ -117,9 +117,9 @@ func (s state) validate() (bool, string) {
 				if ns.InstallTiller && ns.UseTiller {
 					return false, "ERROR: namespaces validation failed -- installTiller and useTiller can't be used together for namespace [ " + k + " ]"
 				}
-				if ns.UseTiller {
+				if ns.UseTiller && verbose {
 					log.Println("INFO: namespace validation -- a pre-installed Tiller is desired to be used in namespace [ " + k + " ].")
-				} else if !ns.InstallTiller {
+				} else if !ns.InstallTiller && verbose {
 					log.Println("INFO: namespace validation -- Tiller is NOT desired to be deployed in namespace [ " + k + " ].")
 				}
 
@@ -136,13 +136,13 @@ func (s state) validate() (bool, string) {
 					if ns.InstallTiller {
 						if !ok1 || !ok2 || !ok3 || !ok4 || !ok5 {
 							log.Println("INFO: namespace validation -- Either no or invalid certs/keys provided for DEPLOYING Tiller with TLS in namespace [ " + k + " ].")
-						} else {
+						} else if verbose {
 							log.Println("INFO: namespace validation -- Tiller is desired to be DEPLOYED with TLS in namespace [ " + k + " ]. ")
 						}
 					} else if ns.UseTiller {
 						if !ok1 || !ok2 || !ok3 {
 							log.Println("INFO: namespace validation -- Either no or invalid certs/keys provided for USING Tiller with TLS in namespace [ " + k + " ].")
-						} else {
+						} else if verbose {
 							log.Println("INFO: namespace validation -- Tiller is desired to be USED with TLS in namespace [ " + k + " ]. ")
 						}
 					}

--- a/utils.go
+++ b/utils.go
@@ -523,3 +523,24 @@ func Indent(s, prefix string) string {
 func isLocalChart(chart string) bool {
 	return filepath.IsAbs(chart)
 }
+
+func generateCmdDescription(r *release, action string) string {
+	var tillerNamespaceMsg string
+	if tillerNamespaceMsg = ""; !settings.Tillerless {
+		tillerNamespaceMsg = "using Tiller in [ " + getDesiredTillerNamespace(r) + " ]"
+	}
+	message := fmt.Sprintf("%s release [ " + r.Name + " ] in namespace [[ " + r.Namespace + " ]] %s", action, tillerNamespaceMsg)
+	return message
+}
+
+func generateDecisionMessage(r *release, message string, isTillerAware bool) string {
+	var tillerNamespaceMsg string
+	if tillerNamespaceMsg = ""; !settings.Tillerless {
+		tillerNamespaceMsg = "using Tiller in [ " + getDesiredTillerNamespace(r) + " ]"
+	}
+	baseMessage := "DECISION: " + message
+	if isTillerAware {
+		return fmt.Sprintf(baseMessage + " %s", tillerNamespaceMsg)
+	}
+	return baseMessage
+}


### PR DESCRIPTION
I was trying to adopt existing DSF file (based on helm 2 with Tiller) to tillerless and found some issues when deleting releases, so decided to fix them.
And I went a bit wider standardising a bit the decision logging. :-)
Also added decisionType ignored for all apps, that were not passed with -target flag, so they are "gray" on plan