### PR TITLE
Fix helm secrets dec command when tillerless enabled

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -109,7 +109,11 @@ func decide(r *release, s *state) {
 // If not configured to run without a tiller will just return `helm`.
 func helmCommand(namespace string) string {
 	if settings.Tillerless {
-		return "helm tiller run " + namespace + " -- helm"
+		if namespace != "" {
+			return "helm tiller run " + namespace + " -- helm"
+		} else {
+			return "helm tiller run helm"
+		}
 	}
 
 	return "helm"

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -621,7 +621,7 @@ func deleteUntrackedRelease(release *release, tillerNamespace string) {
 func decryptSecret(name string) bool {
 	cmd := command{
 		Cmd:         "bash",
-		Args:        []string{"-c", "helm secrets dec " + name},
+		Args:        []string{"-c", helmCommand("") + " secrets dec " + name},
 		Description: "Decrypting " + name,
 	}
 


### PR DESCRIPTION
Since helm secrets by default requires tiller to be reachable, `helm secrets dec` command needs to be wrapped with `helm tiller run`