### PR TITLE
check if chart dir exists instead just path

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -521,7 +521,11 @@ func Indent(s, prefix string) string {
 
 // isLocalChart checks if a chart specified in the DSF is a local directory or not
 func isLocalChart(chart string) bool {
-	return filepath.IsAbs(chart)
+    dir, err := os.Stat(chart)
+    if err == nil {
+        if dir.IsDir() { return true }
+    }
+    return false
 }
 
 func generateCmdDescription(r *release, action string) string {


### PR DESCRIPTION
Checks if directory with file exists instead only checking if path seems to be local.
Fixes #310 