### PR TITLE
Add -group flag to limit execution of deployments to specific group of apps

### DIFF
--- a/decision_maker.go
+++ b/decision_maker.go
@@ -29,12 +29,10 @@ func makePlan(s *state) *plan {
 // decide makes a decision about what commands (actions) need to be executed
 // to make a release section of the desired state come true.
 func decide(r *release, s *state) {
-	// check for presence in defined targets
-	if len(targetMap) > 0 {
-		if _, ok := targetMap[r.Name]; !ok {
-			logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is ignored by target flag. Skipping.", false), r.Priority, ignored)
-			return
-		}
+	// check for presence in defined targets or groups
+	if !isReleaseConsideredToRun(r) {
+		logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is ignored due to passed constraints. Skipping.", false), r.Priority, ignored)
+		return
 	}
 
 	if destroy {

--- a/decision_maker.go
+++ b/decision_maker.go
@@ -30,7 +30,7 @@ func makePlan(s *state) *plan {
 // to make a release section of the desired state come true.
 func decide(r *release, s *state) {
 	// check for presence in defined targets or groups
-	if !isReleaseConsideredToRun(r) {
+	if !r.isReleaseConsideredToRun() {
 		logDecision(generateDecisionMessage(r, "release [ "+r.Name+" ] is ignored due to passed constraints. Skipping.", false), r.Priority, ignored)
 		return
 	}

--- a/decision_maker_test.go
+++ b/decision_maker_test.go
@@ -223,6 +223,73 @@ func Test_decide(t *testing.T) {
 	}
 }
 
+func Test_decide_group(t *testing.T) {
+	type args struct {
+		r *release
+		s *state
+	}
+	tests := []struct {
+		name       string
+		groupFlag  []string
+		targetFlag []string
+		args       args
+		want       decisionType
+	}{
+		{
+			name:       "decide() - groupMap does not contain this service - skip",
+			groupFlag: []string{"some-group"},
+			args: args{
+				r: &release{
+					Name:      "release1",
+					Namespace: "namespace",
+					Enabled:   true,
+				},
+				s: &state{},
+			},
+			want: ignored,
+		},
+		{
+			name:       "decide() - groupMap contains this service - proceed",
+			groupFlag: []string{"run-me"},
+			args: args{
+				r: &release{
+					Name:      "release1",
+					Namespace: "namespace",
+					Enabled:   true,
+					Group:     "run-me",
+				},
+				s: &state{},
+			},
+			want: create,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groupMap = make(map[string]bool)
+			targetMap = make(map[string]bool)
+
+			for _, target := range tt.targetFlag {
+				groupMap[target] = true
+			}
+			for _, group := range tt.groupFlag {
+				groupMap[group] = true
+			}
+			outcome = plan{}
+
+			// Act
+			decide(tt.args.r, tt.args.s)
+			got := outcome.Decisions[0].Type
+			t.Log(outcome.Decisions[0].Description)
+
+			// Assert
+			if got != tt.want {
+				t.Errorf("decide() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 // String allows for pretty printing decisionType const
 func (dt decisionType) String() string {
 	switch dt {

--- a/docs/cmd_reference.md
+++ b/docs/cmd_reference.md
@@ -76,6 +76,9 @@ This lists available CMD options in Helmsman:
 
   `--target`
         limit execution to specific app.
+        
+  `--group`
+        limit execution to specific group of apps.
 
   `--update-deps`
         run 'helm dep up' for local chart     

--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -374,6 +374,7 @@ Options:
 - **version**     : the chart version.
 
 **Optional**
+- **group**       : group name this apps belongs to. It has no effect until Helmsman's flag `-group` is passed. Check this [doc](how_to/misc/limit-deployment-to-specific-group-of-apps.md) for more details.
 - **tillerNamespace** : which Tiller to use for deploying this release. This is available starting from v1.4.0-rc The decision on which Tiller to use for deploying a release follows the following criteria:
    1. If `tillerNamespace`is explicitly defined, it is used.
    2. If `tillerNamespace`is not defined and the namespace in which the release will be deployed has a Tiller installed by Helmsman (i.e. has `installTiller set to true` in the [Namespaces](#namespaces) section), Tiller in that namespace is used.
@@ -412,6 +413,7 @@ Example:
     description = "jenkins"
     namespace = "staging"
     enabled = true
+    group = "critical"
     chart = "stable/jenkins"
     version = "0.9.0"
     valuesFile = ""
@@ -438,6 +440,7 @@ apps:
     description: "jenkins"
     namespace: "staging"
     enabled: true
+    group: "critical"
     chart: "stable/jenkins"
     version: "0.9.0"
     valuesFile: ""

--- a/docs/how_to/README.md
+++ b/docs/how_to/README.md
@@ -46,5 +46,6 @@ This page contains a list of guides on how to use Helmsman.
     - [Send slack notifications from Helmsman](misc/send_slack_notifications_from_helmsman.md)
     - [Merge multiple desired state files](misc/merge_desired_state_files.md)
     - [Limit Helmsman deployment to specific apps](misc/limit-deployment-to-specific-apps.md)
+    - [Limit Helmsman deployment to specific group of apps](misc/limit-deployment-to-specific-group-of-apps.md)
     - [Multi-tenant clusters guide](misc/multitenant_clusters_guide.md)
     - [Helmsman on Windows 10](misc/helmsman_on_windows10.md)

--- a/docs/how_to/misc/limit-deployment-to-specific-group-of-apps.md
+++ b/docs/how_to/misc/limit-deployment-to-specific-group-of-apps.md
@@ -1,0 +1,50 @@
+---
+version: v1.13.0
+---
+
+# Limit execution to explicitly defined group of apps
+
+Starting from v1.13.0, Helmsman allows you to pass the `-group` flag to specify group of apps
+the execution of Helmsman deployment will be limited to. 
+Thanks to this one can deploy specific applications among all defined for an environment.
+
+## Example
+
+Having environment defined with such apps:
+
+* example.yaml:
+```yaml
+# ...
+apps:
+    jenkins:
+      namespace: "staging" # maps to the namespace as defined in namespaces above
+      group: "critical" # group name
+      enabled: true # change to false if you want to delete this app release empty: false:
+      chart: "stable/jenkins" # changing the chart name means delete and recreate this chart
+      version: "0.14.3" # chart version
+
+    artifactory:
+      namespace: "production" # maps to the namespace as defined in namespaces above
+      group: "sidecar" # group name
+      enabled: true # change to false if you want to delete this app release empty: false:
+      chart: "stable/artifactory" # changing the chart name means delete and recreate this chart
+      version: "7.0.6" # chart version
+# ...
+```
+
+running Helmsman with `-f example.yaml` would result in checking state and invoking deployment for both jenkins and artifactory application.
+
+With `-group` flag in command like
+
+```shell
+$ helmsman -f example.yaml -group critical ...
+```
+
+one can execute Helmsman's environment defined with example.yaml limited to only one `jenkins` app, since its group is `critical`. 
+Others are ignored until the flag is defined.
+
+Multiple applications can be set with `-group`, like
+
+```shell
+$ helmsman -f example.yaml -group critical -group sidecar ...
+```

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -272,10 +272,8 @@ func validateReleaseCharts(apps map[string]*release) (bool, string) {
 
 	for app, r := range apps {
 		validateCurrentChart := true
-		if len(targetMap) > 0 {
-			if _, ok := targetMap[r.Name]; !ok {
-				validateCurrentChart = false
-			}
+		if !isReleaseConsideredToRun(r) {
+			validateCurrentChart = false
 		}
 		if validateCurrentChart {
 			if isLocalChart(r.Chart) {
@@ -590,10 +588,8 @@ func cleanUntrackedReleases() {
 	} else {
 		for ns, releases := range toDelete {
 			for r := range releases {
-				if len(targetMap) > 0 {
-					if _, inTarget := targetMap[r.Name]; !inTarget {
-						logDecision(generateDecisionMessage(r, "untracked release [ "+r.Name+" ] is ignored by target flag. Skipping.", false), -800, ignored)
-					}
+				if isReleaseConsideredToRun(r) {
+					logDecision(generateDecisionMessage(r, "untracked release [ "+r.Name+" ] is ignored by target flag. Skipping.", false), -800, ignored)
 				} else {
 					logDecision(generateDecisionMessage(r, "untracked release found: release [ "+r.Name+" ]. It will be deleted", true), -800, delete)
 					deleteUntrackedRelease(r, ns)

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -272,7 +272,7 @@ func validateReleaseCharts(apps map[string]*release) (bool, string) {
 
 	for app, r := range apps {
 		validateCurrentChart := true
-		if !isReleaseConsideredToRun(r) {
+		if !r.isReleaseConsideredToRun() {
 			validateCurrentChart = false
 		}
 		if validateCurrentChart {
@@ -588,7 +588,7 @@ func cleanUntrackedReleases() {
 	} else {
 		for ns, releases := range toDelete {
 			for r := range releases {
-				if isReleaseConsideredToRun(r) {
+				if r.isReleaseConsideredToRun() {
 					logDecision(generateDecisionMessage(r, "untracked release [ "+r.Name+" ] is ignored by target flag. Skipping.", false), -800, ignored)
 				} else {
 					logDecision(generateDecisionMessage(r, "untracked release found: release [ "+r.Name+" ]. It will be deleted", true), -800, delete)

--- a/helm_helpers_test.go
+++ b/helm_helpers_test.go
@@ -32,6 +32,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 	tests := []struct {
 		name       string
 		targetFlag []string
+		groupFlag  []string
 		args       args
 		want       bool
 	}{
@@ -229,9 +230,12 @@ func Test_validateReleaseCharts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			targetMap = make(map[string]bool)
-
+			groupMap = make(map[string]bool)
 			for _, target := range tt.targetFlag {
 				targetMap[target] = true
+			}
+			for _, group := range tt.groupFlag {
+				groupMap[group] = true
 			}
 			if got, msg := validateReleaseCharts(tt.args.apps); got != tt.want {
 				t.Errorf("validateReleaseCharts() = %v, want %v , msg: %v", got, tt.want, msg)

--- a/init.go
+++ b/init.go
@@ -45,6 +45,7 @@ func init() {
 	flag.BoolVar(&debug, "debug", false, "show the execution logs")
 	flag.BoolVar(&dryRun, "dry-run", false, "apply the dry-run option for helm commands.")
 	flag.Var(&target, "target", "limit execution to specific app.")
+	flag.Var(&group, "group", "limit execution to specific group of apps.")
 	flag.BoolVar(&destroy, "destroy", false, "delete all deployed releases. Purge delete is used if the purge option is set to true for the releases.")
 	flag.BoolVar(&v, "v", false, "show the version")
 	flag.BoolVar(&verbose, "verbose", false, "show verbose execution logs")
@@ -87,6 +88,10 @@ func init() {
 
 	if destroy && apply {
 		logError("ERROR: --destroy and --apply can't be used together.")
+	}
+
+	if len(target) > 0 && len(group) > 0 {
+		logError("ERROR: --target and --group can't be used together.")
 	}
 
 	helmVersion = strings.TrimSpace(strings.SplitN(getHelmClientVersion(), ": ", 2)[1])
@@ -203,6 +208,13 @@ func init() {
 		targetMap = map[string]bool{}
 		for _, v := range target {
 			targetMap[v] = true
+		}
+	}
+
+	if len(group) > 0 {
+		groupMap = map[string]bool{}
+		for _, v := range group {
+			groupMap[v] = true
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,9 @@ var helmVersion string
 var kubectlVersion string
 var dryRun bool
 var target stringArray
+var group stringArray
 var targetMap map[string]bool
+var groupMap map[string]bool
 var destroy bool
 var showDiff bool
 var suppressDiffSecrets bool

--- a/release.go
+++ b/release.go
@@ -35,6 +35,24 @@ type release struct {
 	Timeout         int               `yaml:"timeout"`
 }
 
+func (r *release) isReleaseConsideredToRun() bool {
+	if len(targetMap) > 0 {
+		if _, ok := targetMap[r.Name]; ok {
+			return true
+		} else {
+			return false
+		}
+	}
+	if len(groupMap) > 0 {
+		if _, ok := groupMap[r.Group]; ok {
+			return true
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
 // validateRelease validates if a release inside a desired state meets the specifications or not.
 // check the full specification @ https://github.com/Praqma/helmsman/docs/desired_state_spec.md
 func validateRelease(appLabel string, r *release, names map[string]map[string]bool, s state) (bool, string) {

--- a/release.go
+++ b/release.go
@@ -15,6 +15,7 @@ type release struct {
 	Description     string            `yaml:"description"`
 	Namespace       string            `yaml:"namespace"`
 	Enabled         bool              `yaml:"enabled"`
+	Group           string            `yaml:"group"`
 	Chart           string            `yaml:"chart"`
 	Version         string            `yaml:"version"`
 	ValuesFile      string            `yaml:"valuesFile"`

--- a/utils.go
+++ b/utils.go
@@ -557,21 +557,3 @@ func concat(slices ...[]string) []string {
 	}
 	return slice
 }
-
-func isReleaseConsideredToRun(r *release) bool {
-	if len(targetMap) > 0 {
-		if _, ok := targetMap[r.Name]; ok {
-			return true
-		} else {
-			return false
-		}
-	}
-	if len(groupMap) > 0 {
-		if _, ok := groupMap[r.Group]; ok {
-			return true
-		} else {
-			return false
-		}
-	}
-	return true
-}

--- a/utils.go
+++ b/utils.go
@@ -557,3 +557,21 @@ func concat(slices ...[]string) []string {
 	}
 	return slice
 }
+
+func isReleaseConsideredToRun(r *release) bool {
+	if len(targetMap) > 0 {
+		if _, ok := targetMap[r.Name]; ok {
+			return true
+		} else {
+			return false
+		}
+	}
+	if len(groupMap) > 0 {
+		if _, ok := groupMap[r.Group]; ok {
+			return true
+		} else {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Since `-target` turned out to be quite useful, I'm proposing a variation of it in form of `-group` parameter. Each application can have one group it belongs to and the Helmsman's deployment can be not only limited to specific apps, which in bigger environments led to quite hard to prepare final commands, but also limited to groups of applications.
Thanks to this the control over apps deployment will stay on the same level it is for `-target` but with better visibility.