### PR TITLE
Fixing some issues when running in tillerless mode

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 [[constraint]]
   version = "0.3.0"
   name = "github.com/Azure/azure-storage-blob-go"
-  
+
 [[constraint]]
   name = "cloud.google.com/go"
   version = "0.28.0"
@@ -35,11 +35,6 @@
 [[constraint]]
   name = "github.com/BurntSushi/toml"
   version = "0.3.1"
-
-[[constraint]]
-  name = "github.com/Praqma/helmsman"
-  #version = "1.7.4"
-  branch = "master"
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"

--- a/helm_helpers.go
+++ b/helm_helpers.go
@@ -334,19 +334,30 @@ func getChartVersion(r *release) (string, string) {
 		Description: "getting latest chart version " + r.Chart + "-" + r.Version + "",
 	}
 
-	if exitCode, result := cmd.exec(debug, verbose); exitCode != 0 || strings.Contains(result, "No results found") {
+	var (
+		exitCode int
+		result   string
+	)
+
+	if exitCode, result = cmd.exec(debug, verbose); exitCode != 0 || strings.Contains(result, "No results found") {
 		return "", "ERROR: chart " + r.Chart + " with version " + r.Version + " is specified but not found in the helm repos."
-	} else {
-		versions := strings.Split(result, "\n")
-		if len(versions) < 2 {
-			return "", "ERROR: chart " + r.Chart + " with version " + r.Version + " is specified but not found in the helm repos (unrecognized helm output?)."
-		}
-		fields := strings.Split(versions[1], "\t")
-		if len(fields) != 4 {
-			return "", "ERROR: chart " + r.Chart + " with version " + r.Version + " is specified but not found in the helm repos (unrecognized helm output?)."
-		}
-		return strings.TrimSpace(fields[1]), ""
 	}
+	versions := strings.Split(result, "\n")
+	if len(versions) < 2 {
+		return "", "ERROR: chart " + r.Chart + " with version " + r.Version + " is specified but not found in the helm repos (unrecognized helm output?)."
+	}
+	for i, l := range versions {
+		if l == "" || (strings.HasPrefix(strings.TrimSpace(l), "WARNING") && strings.HasSuffix(strings.TrimSpace(l), "CHART VERSION")) {
+			continue
+		} else {
+			fields := strings.Split(versions[i], "\t")
+			if len(fields) != 4 {
+				return "", "ERROR: chart " + r.Chart + " with version " + r.Version + " is specified but not found in the helm repos (unrecognized helm output?)."
+			}
+			return strings.TrimSpace(fields[1]), ""
+		}
+	}
+	return "", "ERROR: chart " + r.Chart + " with version " + r.Version + " is specified but not found in the helm repos."
 }
 
 // waitForTiller keeps checking if the helm Tiller is ready or not by executing helm list and checking its error (if any)
@@ -517,6 +528,21 @@ func initHelmClientOnly() (bool, string) {
 
 	if exitCode, err := cmd.exec(debug, verbose); exitCode != 0 {
 		return false, "ERROR: initializing helm on the client : " + err
+	}
+
+	return true, ""
+}
+
+// initHelmTiller initializes the helm tiller plugin
+func initHelmTiller() (bool, string) {
+	cmd := command{
+		Cmd:         "helm",
+		Args:        []string{"tiler", "install"},
+		Description: "initializing helm tiller plugin.",
+	}
+
+	if exitCode, err := cmd.exec(debug, verbose); exitCode != 0 {
+		return false, "ERROR: initializing helm tiller plugin : " + err
 	}
 
 	return true, ""

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func main() {
 			}
 		} else {
 			log.Println("INFO: running in TILLERLESS mode")
+			initHelmTiller()
 		}
 	}
 


### PR DESCRIPTION
One of the issues is that when the `helm-tiller` plugin is not initialised, tiller will be installed during the first use and that will break the expect json output.

```
12:58:55 ERROR: failed to unmarshal Helm CLI output: unexpected end of JSON input
 [] <nil> 0xc000352180 exit status 1 <nil> <nil> true [0xc0000d6000 0xc0000d6008 0xc000126218] [0xc000126218] [0xc000126210] [0x556fd0] 0xc000120720 <nil>}: exit status 1
stderr: 2019/10/24 12:58:55 ERROR: failed to unmarshal Helm CLI output: unexpected end of JSON input
```

The other issue I'm trying to address is that in some cases `helm search` displays a warning message before the table output and it ended up with the release version being set to `CHART VERSION`.

```
2019/10/24 13:25:05 Command returned with exit code: 1. And error message: Error: chart "my-chart" matching CHART VERSION not found in my-repo index. (try 'helm repo update'). improper constraint: CHART VERSION
Error: plugin "diff" exited with error
Error: plugin "tiller" exited with error
```