### PR TITLE
56% speedup in annotating namespaces annotating with all at once.

### DIFF
--- a/kube_helpers.go
+++ b/kube_helpers.go
@@ -118,18 +118,24 @@ func labelNamespace(ns string, labels map[string]string) {
 
 // annotateNamespace annotates a namespace with provided annotations
 func annotateNamespace(ns string, labels map[string]string) {
-	for k, v := range labels {
-		cmd := command{
-			Cmd:         "kubectl",
-			Args:        []string{"annotate", "--overwrite", "namespace/" + ns, k + "=" + v},
-			Description: "annotating namespace  " + ns,
-		}
+	if len(labels) == 0 {
+		return
+	}
 
-		exitCode, _, _ := cmd.exec(debug, verbose)
-		if exitCode != 0 && verbose {
-			log.Println("WARN: I could not annotate namespace [ " + ns + " with " + k + "=" + v +
-				" ]. It already exists. I am skipping this.")
-		}
+	var annotations string
+	for k, v := range labels {
+		annotations += k + "=" + v + " "
+	}
+	cmd := command{
+		Cmd:         "kubectl",
+		Args:        []string{"annotate", "--overwrite", "namespace/" + ns, annotations},
+		Description: "annotating namespace  " + ns,
+	}
+
+	exitCode, _, _ := cmd.exec(debug, verbose)
+	if exitCode != 0 && verbose {
+		log.Println("WARN: I could not annotate namespace [ " + ns + " with " + annotations +
+			" ]. It already exists. I am skipping this.")
 	}
 }
 


### PR DESCRIPTION
Hi,

This PR annotates namespaces with all annotations at once. It reduces the complexity of the annotation operation from O(n) to O(1).

I noticed that a lot of time was being spent annotating namespaces with one annotation at a time.
Kubectl annotate supports multiple k=v sets at once. This was an easy win I thought.
I've seen a speedup of 56% - but have only tested it sporadically.

Before
```bash
[...SNIP]
$ time helmsman -verbose -f helmsman-deployments.yaml -show-diff -target board -apply
2019/12/13 08:51:25 VERBOSE: kubectl create namespace istio-system
2019/12/13 08:51:27 WARN: I could not create namespace [ istio-system ]. It already exists. I am skipping this.
2019/12/13 08:51:27 VERBOSE: kubectl annotate --overwrite namespace/istio-system collectord.io/index=admin_k8s_istio-system_application
2019/12/13 08:51:28 VERBOSE: kubectl annotate --overwrite namespace/istio-system collectord.io/procstats-index=admin_k8s_istio-system_stats
2019/12/13 08:51:29 VERBOSE: kubectl annotate --overwrite namespace/istio-system collectord.io/procstats-output=splunk
2019/12/13 08:51:30 VERBOSE: kubectl annotate --overwrite namespace/istio-system collectord.io/stats-output=splunk
2019/12/13 08:51:31 VERBOSE: kubectl annotate --overwrite namespace/istio-system collectord.io/stats-index=admin_k8s_istio-system_stats
2019/12/13 08:51:32 VERBOSE: kubectl annotate --overwrite namespace/istio-system collectord.io/logs-escapeterminalsequences=true
2019/12/13 08:51:33 VERBOSE: kubectl annotate --overwrite namespace/istio-system collectord.io/netstats-index=admin_k8s_istio-system_stats
2019/12/13 08:51:34 VERBOSE: kubectl annotate --overwrite namespace/istio-system collectord.io/netstats-output=splunk
2019/12/13 08:51:35 VERBOSE: kubectl annotate --overwrite namespace/istio-system collectord.io/nettable-index=admin_k8s_istio-system_stats
2019/12/13 08:51:36 VERBOSE: kubectl annotate --overwrite namespace/istio-system collectord.io/nettable-output=splunk
2019/12/13 08:51:37 VERBOSE: kubectl create namespace jenkins
2019/12/13 08:51:38 WARN: I could not create namespace [ jenkins ]. It already exists. I am skipping this.
2019/12/13 08:51:38 VERBOSE: kubectl label --overwrite namespace/jenkins env=jenkins
2019/12/13 08:51:39 VERBOSE: kubectl annotate --overwrite namespace/jenkins collectord.io/procstats-index=admin_k8s_jenkins_stats
2019/12/13 08:51:40 VERBOSE: kubectl annotate --overwrite namespace/jenkins collectord.io/procstats-output=splunk
2019/12/13 08:51:41 VERBOSE: kubectl annotate --overwrite namespace/jenkins collectord.io/stats-index=admin_k8s_jenkins_stats
2019/12/13 08:51:42 VERBOSE: kubectl annotate --overwrite namespace/jenkins collectord.io/logs-escapeterminalsequences=true
2019/12/13 08:51:43 VERBOSE: kubectl annotate --overwrite namespace/jenkins collectord.io/netstats-index=admin_k8s_jenkins_stats
2019/12/13 08:51:44 VERBOSE: kubectl annotate --overwrite namespace/jenkins collectord.io/netstats-output=splunk
2019/12/13 08:51:44 VERBOSE: kubectl annotate --overwrite namespace/jenkins collectord.io/nettable-output=splunk
2019/12/13 08:51:45 VERBOSE: kubectl annotate --overwrite namespace/jenkins collectord.io/index=admin_k8s_jenkins_application
2019/12/13 08:51:46 VERBOSE: kubectl annotate --overwrite namespace/jenkins collectord.io/nettable-index=admin_k8s_jenkins_stats
2019/12/13 08:51:47 VERBOSE: kubectl annotate --overwrite namespace/jenkins collectord.io/stats-output=splunk
2019/12/13 08:51:48 VERBOSE: kubectl create namespace polaris
2019/12/13 08:51:49 WARN: I could not create namespace [ polaris ]. It already exists. I am skipping this.
2019/12/13 08:51:49 VERBOSE: kubectl label --overwrite namespace/polaris env=polaris
2019/12/13 08:51:50 VERBOSE: kubectl annotate --overwrite namespace/polaris collectord.io/stats-output=splunk
2019/12/13 08:51:51 VERBOSE: kubectl annotate --overwrite namespace/polaris collectord.io/logs-escapeterminalsequences=true
2019/12/13 08:51:52 VERBOSE: kubectl annotate --overwrite namespace/polaris collectord.io/netstats-output=splunk
2019/12/13 08:51:53 VERBOSE: kubectl annotate --overwrite namespace/polaris collectord.io/nettable-index=admin_k8s_polaris_stats
2019/12/13 08:51:54 VERBOSE: kubectl annotate --overwrite namespace/polaris collectord.io/procstats-index=admin_k8s_polaris_stats
2019/12/13 08:51:55 VERBOSE: kubectl annotate --overwrite namespace/polaris collectord.io/procstats-output=splunk
2019/12/13 08:51:56 VERBOSE: kubectl annotate --overwrite namespace/polaris collectord.io/stats-index=admin_k8s_polaris_stats
2019/12/13 08:51:57 VERBOSE: kubectl annotate --overwrite namespace/polaris collectord.io/index=admin_k8s_polaris_application
2019/12/13 08:51:58 VERBOSE: kubectl annotate --overwrite namespace/polaris collectord.io/netstats-index=admin_k8s_polaris_stats
2019/12/13 08:51:59 VERBOSE: kubectl annotate --overwrite namespace/polaris collectord.io/nettable-output=splunk
2019/12/13 08:52:00 VERBOSE: kubectl create namespace idp
2019/12/13 08:52:01 WARN: I could not create namespace [ idp ]. It already exists. I am skipping this.
2019/12/13 08:52:01 VERBOSE: kubectl label --overwrite namespace/idp env=idp
2019/12/13 08:52:02 VERBOSE: kubectl annotate --overwrite namespace/idp collectord.io/index=admin_k8s_idp_application
2019/12/13 08:52:03 VERBOSE: kubectl annotate --overwrite namespace/idp collectord.io/logs-escapeterminalsequences=true
2019/12/13 08:52:04 VERBOSE: kubectl annotate --overwrite namespace/idp collectord.io/netstats-index=admin_k8s_idp_stats
2019/12/13 08:52:05 VERBOSE: kubectl annotate --overwrite namespace/idp collectord.io/nettable-index=admin_k8s_idp_stats
2019/12/13 08:52:06 VERBOSE: kubectl annotate --overwrite namespace/idp collectord.io/procstats-index=admin_k8s_idp_stats
2019/12/13 08:52:06 VERBOSE: kubectl annotate --overwrite namespace/idp collectord.io/procstats-output=splunk
2019/12/13 08:52:07 VERBOSE: kubectl annotate --overwrite namespace/idp collectord.io/stats-index=admin_k8s_idp_stats
2019/12/13 08:52:08 VERBOSE: kubectl annotate --overwrite namespace/idp collectord.io/netstats-output=splunk
2019/12/13 08:52:09 VERBOSE: kubectl annotate --overwrite namespace/idp collectord.io/nettable-output=splunk
2019/12/13 08:52:10 VERBOSE: kubectl annotate --overwrite namespace/idp collectord.io/stats-output=splunk
[...SNIP]
helmsman -verbose -f helmsman-deployments.yaml -show-diff -target board -appl  18.31s user 7.19s system 31% cpu 1:21.84 total
``` 

After
```
$ time ~/go/src/github.com/lhotrifork/helmsman/helmsman -verbose -f helmsman-deployments.yaml -show-diff -target board -apply
[SNIP]
2019/12/13 08:57:02 VERBOSE: kubectl create namespace polaris
2019/12/13 08:57:04 WARN: I could not create namespace [ polaris ]. It already exists. I am skipping this.
2019/12/13 08:57:04 VERBOSE: kubectl label --overwrite namespace/polaris env=polaris
2019/12/13 08:57:05 VERBOSE: kubectl annotate --overwrite namespace/polaris collectord.io/netstats-index=admin_k8s_polaris_stats collectord.io/netstats-output=splunk collectord.io/nettable-index=admin_k8s_polaris_stats collectord.io/nettable-output=splunk collectord.io/procstats-output=splunk collectord.io/stats-index=admin_k8s_polaris_stats collectord.io/logs-escapeterminalsequences=true collectord.io/procstats-index=admin_k8s_polaris_stats collectord.io/stats-output=splunk collectord.io/index=admin_k8s_polaris_application
2019/12/13 08:57:06 VERBOSE: kubectl create namespace idp
2019/12/13 08:57:07 WARN: I could not create namespace [ idp ]. It already exists. I am skipping this.
2019/12/13 08:57:07 VERBOSE: kubectl label --overwrite namespace/idp env=idp
2019/12/13 08:57:08 VERBOSE: kubectl annotate --overwrite namespace/idp collectord.io/nettable-index=admin_k8s_idp_stats collectord.io/nettable-output=splunk collectord.io/procstats-index=admin_k8s_idp_stats collectord.io/stats-output=splunk collectord.io/netstats-output=splunk collectord.io/logs-escapeterminalsequences=true collectord.io/netstats-index=admin_k8s_idp_stats collectord.io/procstats-output=splunk collectord.io/stats-index=admin_k8s_idp_stats collectord.io/index=admin_k8s_idp_application
2019/12/13 08:57:09 VERBOSE: kubectl create namespace kube-system
2019/12/13 08:57:10 WARN: I could not create namespace [ kube-system ]. It already exists. I am skipping this.
2019/12/13 08:57:10 VERBOSE: kubectl annotate --overwrite namespace/kube-system
2019/12/13 08:57:10 WARN: I could not annotate namespace [ kube-system with  ]. It already exists. I am skipping this.
2019/12/13 08:57:10 VERBOSE: kubectl create namespace istio-system
2019/12/13 08:57:11 WARN: I could not create namespace [ istio-system ]. It already exists. I am skipping this.
2019/12/13 08:57:11 VERBOSE: kubectl annotate --overwrite namespace/istio-system collectord.io/logs-escapeterminalsequences=true collectord.io/nettable-output=splunk collectord.io/stats-output=splunk collectord.io/index=admin_k8s_istio-system_application collectord.io/netstats-index=admin_k8s_istio-system_stats collectord.io/netstats-output=splunk collectord.io/nettable-index=admin_k8s_istio-system_stats collectord.io/procstats-index=admin_k8s_istio-system_stats collectord.io/procstats-output=splunk collectord.io/stats-index=admin_k8s_istio-system_stats
2019/12/13 08:57:12 VERBOSE: kubectl create namespace jenkins
2019/12/13 08:57:12 WARN: I could not create namespace [ jenkins ]. It already exists. I am skipping this.
2019/12/13 08:57:12 VERBOSE: kubectl label --overwrite namespace/jenkins env=jenkins
2019/12/13 08:57:13 VERBOSE: kubectl annotate --overwrite namespace/jenkins collectord.io/netstats-index=admin_k8s_jenkins_stats collectord.io/nettable-index=admin_k8s_jenkins_stats collectord.io/nettable-output=splunk collectord.io/procstats-output=splunk collectord.io/stats-index=admin_k8s_jenkins_stats collectord.io/stats-output=splunk collectord.io/index=admin_k8s_jenkins_application collectord.io/logs-escapeterminalsequences=true collectord.io/netstats-output=splunk collectord.io/procstats-index=admin_k8s_jenkins_stats
[SNIP]
~/go/src/github.com/lhotrifork/helmsman/helmsman -verbose -f  -show-diff     10.65s user 3.75s system 31% cpu 46.039 total
```

Before: 81 seconds
After: 46 seconds 
= 56% speedup