### PR TITLE
Fix/untracked releases for helmsman 3.0.0-beta

### DIFF
--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -1,4 +1,4 @@
-# version: v1.5.0
+# version: v3.0.0-beta1
 # metadata -- add as many key/value pairs as you want
 metadata:
   org: "example.com/$ORG_PATH/"
@@ -8,7 +8,7 @@ metadata:
 # paths to the certificate for connecting to the cluster
 # You can skip this if you use Helmsman on a machine with kubectl already connected to your k8s cluster.
 # you have to use exact key names here : 'caCrt' for certificate and 'caKey' for the key and caClient for the client certificate
-certificates:
+# certificates:
   #caClient: "gs://mybucket/client.crt" # GCS bucket path
   #caCrt: "s3://mybucket/ca.crt" # S3 bucket path
   #caKey: "../ca.key" # valid local file relative path
@@ -17,20 +17,19 @@ settings:
   kubeContext: "minikube" # will try connect to this context first, if it does not exist, it will be created using the details below
   #username: "admin"
   #password: "$K8S_PASSWORD" # the name of an environment variable containing the k8s password
-  clusterURI: "$SET_URI" # the name of an environment variable containing the cluster API
+  #clusterURI: "$SET_URI" # the name of an environment variable containing the cluster API
   #clusterURI: "https://192.168.99.100:8443" # equivalent to the above
   #serviceAccount: "foo" # k8s serviceaccount must be already defined, validation error will be thrown otherwise
-  storageBackend: "secret" # default is configMap
+  storageBackend: "secret" 
   #slackWebhook:  "$slack" # or your slack webhook url
   #reverseDelete: false # reverse the priorities on delete
   #### to use bearer token:
   #  bearerToken: true
   #  clusterURI: "https://kubernetes.default"
-  #tillerless: true # runs helm in tillerless mode using
 
 # define your environments and their k8s namespaces
 namespaces:
-  production:
+  test1:
     protected: true
     limits:
       - type: Container
@@ -53,8 +52,8 @@ namespaces:
 # syntax: repo_name: "repo_url"
 # only private repos hosted in s3 buckets are now supported
 helmRepos:
-  stable: "https://kubernetes-charts.storage.googleapis.com"
-  incubator: "http://storage.googleapis.com/kubernetes-charts-incubator"
+  argo: "https://argoproj.github.io/argo-helm"
+  jfrog: "https://charts.jfrog.io"
   #myS3repo: "s3://my-S3-private-repo/charts"
   #myGCSrepo: "gs://my-GCS-private-repo/charts"
   #custom:  "https://user:pass@mycustomrepo.org"
@@ -62,44 +61,25 @@ helmRepos:
 # define the desired state of your applications helm charts
 # each contains the following:
 
-
 apps:
 
     # jenkins will be deployed using the Tiller in the staging namespace
-    jenkins:
-      namespace: "staging" # maps to the namespace as defined in namespaces above
+    argo:
+      namespace: "test1" # maps to the namespace as defined in namespaces above
       enabled: true # change to false if you want to delete this app release empty: false:
-      chart: "stable/jenkins" # changing the chart name means delete and recreate this chart
-      version: "0.14.3" # chart version
-      ### Optional values below
-      name: "jenkins" # should be unique across all apps
-      description: "jenkins"
-      valuesFile: "" # leaving it empty uses the default chart values
-      purge: false # will only be considered when there is a delete operation
-      test: false # run the tests when this release is installed for the first time only
+      chart: "argo/argo" # changing the chart name means delete and recreate this chart
+      version: "0.6.4" # chart version
       protected: true
       priority: -3
       wait: true
-      #tillerNamespace: "kube-system" # which Tiller to use to deploy this release
-      set: # values to override values from values.yaml with values from env vars-- useful for passing secrets to charts
-        AdminPassword: "$JENKINS_PASSWORD" # $JENKINS_PASSWORD must exist in the environment
-        AdminUser: "admin"
-      setString:
-        MyLongIntVar: "1234567890"
 
 
     # artifactory will be deployed using the Tiller in the kube-system namespace
     artifactory:
-      namespace: "production" # maps to the namespace as defined in namespaces above
+      namespace: "test1" # maps to the namespace as defined in namespaces above
       enabled: true # change to false if you want to delete this app release empty: false:
-      chart: "stable/artifactory" # changing the chart name means delete and recreate this chart
-      version: "7.0.6" # chart version
-      ### Optional values below
-      name: "artifactory" # should be unique across all apps
-      description: "artifactory"
-      valuesFile: "" # leaving it empty uses the default chart values
-      purge: false # will only be considered when there is a delete operation
-      test: false # run the tests when this release is installed for the first time only
+      chart: "jfrog/artifactory" # changing the chart name means delete and recreate this chart
+      version: "8.3.2" # chart version
       priority: -2
 
 # See https://github.com/Praqma/helmsman/blob/master/docs/desired_state_specification.md#apps for more apps options

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -3,10 +3,11 @@ package app
 import (
 	"flag"
 	"fmt"
-	"github.com/imdario/mergo"
-	"github.com/joho/godotenv"
 	"os"
 	"strings"
+
+	"github.com/imdario/mergo"
+	"github.com/joho/godotenv"
 )
 
 const (
@@ -29,6 +30,7 @@ func printUsage() {
 	flag.PrintDefaults()
 }
 
+// Cli parses cmd flags, validates them and performs some initializations
 func Cli() {
 	//parsing command line flags
 	flag.Var(&files, "f", "desired state file name(s), may be supplied more than once to merge state files")

--- a/internal/app/helm_helpers.go
+++ b/internal/app/helm_helpers.go
@@ -18,6 +18,7 @@ var currentState map[string]releaseState
 
 // releaseState represents the current state of a release
 type releaseState struct {
+	Name      string
 	Revision  int
 	Updated   time.Time
 	Status    string
@@ -97,6 +98,7 @@ func buildState() {
 		}
 		revision, _ := strconv.Atoi(rel[i].Revision)
 		currentState[fmt.Sprintf("%s-%s", rel[i].Name, rel[i].Namespace)] = releaseState{
+			Name:      rel[i].Name,
 			Revision:  revision,
 			Updated:   date,
 			Status:    rel[i].Status,
@@ -296,12 +298,12 @@ func addHelmRepos(repos map[string]string) (bool, string) {
 }
 
 // cleanUntrackedReleases checks for any releases that are managed by Helmsman and are no longer tracked by the desired state
-// It compares the currently deployed releases with "MANAGED-BY=HELMSMAN" labels with Apps defined in the desired state
-// For all untracked releases found, a decision is made to delete them and is added to the Helmsman plan
+// It compares the currently deployed releases labeled with "MANAGED-BY=HELMSMAN" with Apps defined in the desired state
+// For all untracked releases found, a decision is made to uninstall them and is added to the Helmsman plan
 // NOTE: Untracked releases don't benefit from either namespace or application protection.
 // NOTE: Removing/Commenting out an app from the desired state makes it untracked.
 func cleanUntrackedReleases() {
-	toDelete := make(map[string]map[*release]bool)
+	toDelete := make(map[string]map[releaseState]bool)
 	log.Info("Checking if any Helmsman managed releases are no longer tracked by your desired state ...")
 	for ns, releases := range getHelmsmanReleases() {
 		for r := range releases {
@@ -313,7 +315,7 @@ func cleanUntrackedReleases() {
 			}
 			if !tracked {
 				if _, ok := toDelete[ns]; !ok {
-					toDelete[ns] = make(map[*release]bool)
+					toDelete[ns] = make(map[releaseState]bool)
 				}
 				toDelete[ns][r] = true
 			}
@@ -325,19 +327,15 @@ func cleanUntrackedReleases() {
 	} else {
 		for _, releases := range toDelete {
 			for r := range releases {
-				if r.isReleaseConsideredToRun() {
-					logDecision("Untracked release [ "+r.Name+" ] found but it's ignored by target flag", -800, ignored)
-				} else {
-					logDecision("Untracked release [ "+r.Name+" ] found and it will be deleted", -800, delete)
-					uninstallUntrackedRelease(r)
-				}
+				logDecision("Untracked release [ "+r.Name+" ] found and it will be deleted", -800, delete)
+				uninstallUntrackedRelease(r)
 			}
 		}
 	}
 }
 
-// uninstallUntrackedRelease creates the helm command to purge delete an untracked release
-func uninstallUntrackedRelease(release *release) {
+// uninstallUntrackedRelease creates the helm command to uninstall an untracked release
+func uninstallUntrackedRelease(release releaseState) {
 	cmd := command{
 		Cmd:         helmBin,
 		Args:        concat([]string{"uninstall", release.Name, "--namespace", release.Namespace}, getDryRunFlags()),

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -60,6 +60,7 @@ func init() {
 	Cli()
 }
 
+// Main is the app main function
 func Main() {
 	// delete temp files with substituted env vars when the program terminates
 	defer os.RemoveAll(tempFilesDir)

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -31,20 +31,19 @@ type release struct {
 	Timeout      int               `yaml:"timeout"`
 }
 
+// isReleaseConsideredToRun checks if a release is being targeted for operations as specified by user cmd flags (--group or --target)
 func (r *release) isReleaseConsideredToRun() bool {
 	if len(targetMap) > 0 {
 		if _, ok := targetMap[r.Name]; ok {
 			return true
-		} else {
-			return false
 		}
+		return false
 	}
 	if len(groupMap) > 0 {
 		if _, ok := groupMap[r.Group]; ok {
 			return true
-		} else {
-			return false
 		}
+		return false
 	}
 	return true
 }


### PR DESCRIPTION
this PR updates the detection of untracked releases to match helm3 and the recent helmsman rewrites.
The expected behaviour remains the same. If a release is no longer in the desired state file(s) but is deployed in the cluster and labeled as MANAGED-BY=HELMSMAN, then it is considered untracked and should be removed (unless user enables the `--keep-untracked-releases` flag)

@mkubaczyk  I removed the check if the release is targeted before deleting it because it didn't make sense that the release is not in the desired state but is being targeted. Maybe I am missing something?