### PR TITLE
Feature/add context labels to identify different DSFs

### DIFF
--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -8,6 +8,7 @@ This document describes the specification for how to write your Helm charts' des
 
 - [Metadata](#metadata) [Optional] -- metadata for any human reader of the desired state file.
 - [Certificates](#certificates) [Optional] -- only needed when you want Helmsman to connect kubectl to your cluster for you.
+- [Context](#context) [optional] -- define the context in which a DSF is used.
 - [Settings](#settings) [Optional] -- data about your k8s cluster and how to deploy Helm on it if needed.
 - [Namespaces](#namespaces) -- defines the namespaces where you want your Helm charts to be deployed.
 - [Helm Repos](#helm-repos) [Optional] -- defines the repos where you want to get Helm charts from.
@@ -74,6 +75,16 @@ certificates:
   caClient: "../path/to/my/local/client-certificate.crt"
   #caClient: "$CA_CLIENT"
 ```
+## Context
+
+Optional : Yes.
+
+Synopsis: defines the context in which a DSF is used. This context is used as the ID of that specific DSF and must be unique across the used DSFs. If not defined, `default` is used. Check [here](how_to/misc/merge_desired_state_files.md) for more details on the limitations.
+
+```yaml
+context: prod-apps
+...
+```  
 
 ## Settings
 

--- a/docs/how_to/misc/merge_desired_state_files.md
+++ b/docs/how_to/misc/merge_desired_state_files.md
@@ -42,3 +42,73 @@ One can then run the following to use the merged config of the above files, with
 ```shell
 $ helmsman -f common.toml -f nonprod.toml ...
 ```
+
+## Distinguishing releases deployed from different Desired State Files
+
+When using multiple DSFs -and since Helmsman doesn't maintain any external state-, it has been possible for operations from one DSF to cause problems to releases deployed by other DSFs. A typical example is that releases deployed by other DSFs are considered `untracked` and get scheduled for deleting. Workarounds existed (e.g. using the `--keep-untracked-releases`, `--target` and `--group` flags). 
+
+Starting from Helmsman v3.0.0-beta1, `context` is introduced to define the context in which a DSF is used. This context is used as the ID of that specific DSF and must be unique across the used DSFs. The context is then used to label the different releases to link them to the DSF they were first deployed from. These labels are then checked by Helmsman on each run to make sure operations are limited to releases from a specific context.
+
+Here is how it is used: 
+
+* `prod.yaml`:
+```yaml
+settings:
+  kubeContext: "cluster"
+  storageBackend: "secret"
+
+namespaces: 
+  infra:
+    protected: true
+
+...
+```
+
+* `infra.yaml`:
+```yaml
+context: infra-apps
+settings:
+  kubeContext: "cluster"
+  storageBackend: "secret"
+
+namespaces: 
+  infra:
+    protected: true
+
+apps:
+  external-dns:
+    namespace: infra
+    valuesFile: "./external-dns/values.yaml"
+    ...
+
+  cert-issuer:
+    namespace: infra
+    valuesFile: "./cert-issuer/nonprod.yaml"
+    ...
+...
+```
+
+* `prod.yaml`:
+```yaml
+context: prod-apps
+settings:
+  kubeContext: "cluster"
+  storageBackend: "secret"
+
+namespaces: 
+  prod:
+    protected: true
+
+apps:
+  my-prod-app:
+    namespace: prod
+    valuesFile: "./my-prod-app/values.yaml"
+    ...
+...
+```
+
+### Limitations
+
+- If no context is provided in DSF (or merged DSFs), `default` is applied as a default context. This means any set of DSFs that don't define custom contexts can still operate on each other's releases (same behavior as in Helmsman 1.x).
+
+- When merging multiple DSFs, context from the firs DSF in the list gets overridden by the context in the last DSF.

--- a/docs/how_to/misc/merge_desired_state_files.md
+++ b/docs/how_to/misc/merge_desired_state_files.md
@@ -51,19 +51,6 @@ Starting from Helmsman v3.0.0-beta1, `context` is introduced to define the conte
 
 Here is how it is used: 
 
-* `prod.yaml`:
-```yaml
-settings:
-  kubeContext: "cluster"
-  storageBackend: "secret"
-
-namespaces: 
-  infra:
-    protected: true
-
-...
-```
-
 * `infra.yaml`:
 ```yaml
 context: infra-apps
@@ -112,3 +99,5 @@ apps:
 - If no context is provided in DSF (or merged DSFs), `default` is applied as a default context. This means any set of DSFs that don't define custom contexts can still operate on each other's releases (same behavior as in Helmsman 1.x).
 
 - When merging multiple DSFs, context from the firs DSF in the list gets overridden by the context in the last DSF.
+
+- If multiple DSFs use the same context name, they will mess up each other's releases.

--- a/examples/example.toml
+++ b/examples/example.toml
@@ -14,6 +14,10 @@
 #  caCrt = "s3://mybucket/ca.crt" # S3 bucket path
 #  caKey = "../ca.key" # valid local file relative path
 
+# context defines the context of this Desired State File. 
+# It is used to allow Helmsman identify which releases are managed by which DSF.
+# Therefore, it is important that each DSF uses a unique context.
+context= "test-infra"   # defaults to "default" if not provided
 
 [settings]
   kubeContext = "minikube" # will try connect to this context first, if it does not exist, it will be created using the details below

--- a/examples/example.toml
+++ b/examples/example.toml
@@ -1,4 +1,10 @@
-# version: v1.6.2
+# version: v3.0.0-beta1
+
+# context defines the context of this Desired State File. 
+# It is used to allow Helmsman identify which releases are managed by which DSF.
+# Therefore, it is important that each DSF uses a unique context.
+context= "test-infra"   # defaults to "default" if not provided
+
 # metadata -- add as many key/value pairs as you want
 [metadata]
   org = "example.com/${ORG_PATH}/"
@@ -13,11 +19,6 @@
 #  caClient = "gs://mybucket/client.crt" # GCS bucket path
 #  caCrt = "s3://mybucket/ca.crt" # S3 bucket path
 #  caKey = "../ca.key" # valid local file relative path
-
-# context defines the context of this Desired State File. 
-# It is used to allow Helmsman identify which releases are managed by which DSF.
-# Therefore, it is important that each DSF uses a unique context.
-context= "test-infra"   # defaults to "default" if not provided
 
 [settings]
   kubeContext = "minikube" # will try connect to this context first, if it does not exist, it will be created using the details below

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -16,7 +16,7 @@ metadata:
 # context defines the context of this Desired State File. 
 # It is used to allow Helmsman identify which releases are managed by which DSF.
 # Therefore, it is important that each DSF uses a unique context.
-context: test-infra   # defaults to file name if not provided
+context: test-infra   # defaults to "default" if not provided
 
 settings:
   kubeContext: "minikube" # will try connect to this context first, if it does not exist, it will be created using the details below

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -13,6 +13,11 @@ metadata:
   #caCrt: "s3://mybucket/ca.crt" # S3 bucket path
   #caKey: "../ca.key" # valid local file relative path
 
+# context defines the context of this Desired State File. 
+# It is used to allow Helmsman identify which releases are managed by which DSF.
+# Therefore, it is important that each DSF uses a unique context.
+context: test-infra   # defaults to file name if not provided
+
 settings:
   kubeContext: "minikube" # will try connect to this context first, if it does not exist, it will be created using the details below
   #username: "admin"

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -200,10 +200,6 @@ func Cli() {
 		s.print()
 	}
 
-	if s.Settings.StorageBackend != "" {
-		os.Setenv("HELM_DRIVER", s.Settings.StorageBackend)
-	}
-
 	if !skipValidation {
 		// validate the desired state content
 		if len(files) > 0 {
@@ -213,6 +209,20 @@ func Cli() {
 		}
 	} else {
 		log.Info("Desired state validation is skipped.")
+	}
+
+	if s.Settings.StorageBackend != "" {
+		os.Setenv("HELM_DRIVER", s.Settings.StorageBackend)
+	}
+
+	// set default storage background to secret if not set by user
+	if s.Settings.StorageBackend == "" {
+		s.Settings.StorageBackend = "secret"
+	}
+
+	// if there is no user-defined context name in the DSF(s), use the default context name
+	if s.Context == "" {
+		s.Context = defaultContextName
 	}
 
 	if len(target) > 0 {

--- a/internal/app/decision_maker_test.go
+++ b/internal/app/decision_maker_test.go
@@ -228,8 +228,9 @@ func Test_decide(t *testing.T) {
 
 func Test_decide_group(t *testing.T) {
 	type args struct {
-		r *release
-		s *state
+		r            *release
+		s            *state
+		currentState *map[string]releaseState
 	}
 	tests := []struct {
 		name       string
@@ -248,6 +249,12 @@ func Test_decide_group(t *testing.T) {
 					Enabled:   true,
 				},
 				s: &state{},
+				currentState: &map[string]releaseState{
+					"release1-namespace": {
+						Namespace: "namespace",
+						Chart:     "chart-1.0.0",
+					},
+				},
 			},
 			want: ignored,
 		},
@@ -261,7 +268,17 @@ func Test_decide_group(t *testing.T) {
 					Enabled:   true,
 					Group:     "run-me",
 				},
-				s: &state{},
+				s: &state{
+					Context: "default",
+				},
+				currentState: &map[string]releaseState{
+					"release2-namespace": {
+						Name:            "release2",
+						Namespace:       "namespace",
+						Chart:           "chart-1.0.0",
+						HelmsmanContext: "some-other-context",
+					},
+				},
 			},
 			want: create,
 		},
@@ -271,6 +288,7 @@ func Test_decide_group(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			groupMap = make(map[string]bool)
 			targetMap = make(map[string]bool)
+			currentState = *tt.args.currentState
 
 			for _, target := range tt.targetFlag {
 				groupMap[target] = true

--- a/internal/app/helm_helpers.go
+++ b/internal/app/helm_helpers.go
@@ -18,12 +18,13 @@ var currentState map[string]releaseState
 
 // releaseState represents the current state of a release
 type releaseState struct {
-	Name      string
-	Revision  int
-	Updated   time.Time
-	Status    string
-	Chart     string
-	Namespace string
+	Name            string
+	Revision        int
+	Updated         time.Time
+	Status          string
+	Chart           string
+	Namespace       string
+	HelmsmanContext string
 }
 
 type releaseInfo struct {
@@ -98,12 +99,13 @@ func buildState() {
 		}
 		revision, _ := strconv.Atoi(rel[i].Revision)
 		currentState[fmt.Sprintf("%s-%s", rel[i].Name, rel[i].Namespace)] = releaseState{
-			Name:      rel[i].Name,
-			Revision:  revision,
-			Updated:   date,
-			Status:    rel[i].Status,
-			Chart:     rel[i].Chart,
-			Namespace: rel[i].Namespace,
+			Name:            rel[i].Name,
+			Revision:        revision,
+			Updated:         date,
+			Status:          rel[i].Status,
+			Chart:           rel[i].Chart,
+			Namespace:       rel[i].Namespace,
+			HelmsmanContext: getReleaseContext(rel[i].Name, rel[i].Namespace),
 		}
 	}
 }
@@ -114,7 +116,7 @@ func buildState() {
 // If status is provided as an input [deployed, deleted, failed], then the search will verify the release status matches the search status.
 func isReleaseExisting(r *release, status string) bool {
 	v, ok := currentState[fmt.Sprintf("%s-%s", r.Name, r.Namespace)]
-	if !ok {
+	if !ok || v.HelmsmanContext != s.Context {
 		return false
 	}
 

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -55,6 +55,7 @@ var noDefaultRepos bool
 const tempFilesDir = ".helmsman-tmp"
 const stableHelmRepo = "https://kubernetes-charts.storage.googleapis.com"
 const incubatorHelmRepo = "http://storage.googleapis.com/kubernetes-charts-incubator"
+const defaultContextName = "default"
 
 func init() {
 	Cli()

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -30,6 +30,7 @@ type state struct {
 	Metadata               map[string]string    `yaml:"metadata"`
 	Certificates           map[string]string    `yaml:"certificates"`
 	Settings               config               `yaml:"settings"`
+	Context                string               `yaml:"context"`
 	Namespaces             map[string]namespace `yaml:"namespaces"`
 	HelmRepos              map[string]string    `yaml:"helmRepos"`
 	PreconfiguredHelmRepos []string             `yaml:"preconfiguredHelmRepos"`
@@ -163,6 +164,9 @@ func (s state) print() {
 	fmt.Println("\nMetadata: ")
 	fmt.Println("--------- ")
 	printMap(s.Metadata, 0)
+	fmt.Println("\nContext: ")
+	fmt.Println("--------- ")
+	fmt.Println(s.Context)
 	fmt.Println("\nCertificates: ")
 	fmt.Println("--------- ")
 	printMap(s.Certificates, 0)


### PR DESCRIPTION
This PR introduces a `context` stanza in the Desired State File (DSF) to be used as an identity for each DSF allowing Helmsman to distinguish which releases are managed by which DSF.

@mkubaczyk @luisdavim it would be nice if you can have a quick look in case I missed something.
Meanwhile, I will work on updating the docs to release 3.0.0-beta1.