### PR TITLE
Add goroutines-based parallel execution of plan and charts availability checking

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,19 +42,6 @@
   version = "v0.3.1"
 
 [[projects]]
-  digest = "1:c3fabcdfd716824af4b7b60fd85c15df57c7bbed220a0703212e347b42e7a803"
-  name = "github.com/Praqma/helmsman"
-  packages = [
-    "internal/app",
-    "internal/aws",
-    "internal/azure",
-    "internal/gcs",
-  ]
-  pruneopts = "UT"
-  revision = "16473a838593436cbb46748fa37d0c89a73d369e"
-  version = "v3.0.0-beta1"
-
-[[projects]]
   digest = "1:efe5038e25001cc88547d8ecc9ed76bbb97c15826b9bb91b931ec30dacb4e3f1"
   name = "github.com/apsdehal/go-logger"
   packages = ["."]
@@ -475,10 +462,6 @@
     "github.com/Azure/azure-pipeline-go/pipeline",
     "github.com/Azure/azure-storage-blob-go/azblob",
     "github.com/BurntSushi/toml",
-    "github.com/Praqma/helmsman/internal/app",
-    "github.com/Praqma/helmsman/internal/aws",
-    "github.com/Praqma/helmsman/internal/azure",
-    "github.com/Praqma/helmsman/internal/gcs",
     "github.com/apsdehal/go-logger",
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/session",

--- a/internal/app/decision_maker_test.go
+++ b/internal/app/decision_maker_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 )
 
@@ -209,9 +210,11 @@ func Test_decide(t *testing.T) {
 				targetMap[target] = true
 			}
 			outcome = plan{}
-
+			wg := sync.WaitGroup{}
+			wg.Add(1)
 			// Act
-			decide(tt.args.r, tt.args.s)
+			decide(tt.args.r, tt.args.s, &wg)
+			wg.Wait()
 			got := outcome.Decisions[0].Type
 			t.Log(outcome.Decisions[0].Description)
 
@@ -294,9 +297,10 @@ func Test_decide_group(t *testing.T) {
 				groupMap[group] = true
 			}
 			outcome = plan{}
-
-			// Act
-			decide(tt.args.r, tt.args.s)
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			decide(tt.args.r, tt.args.s, &wg)
+			wg.Wait()
 			got := outcome.Decisions[0].Type
 			t.Log(outcome.Decisions[0].Description)
 

--- a/internal/app/helm_helpers_test.go
+++ b/internal/app/helm_helpers_test.go
@@ -225,8 +225,16 @@ func Test_validateReleaseCharts(t *testing.T) {
 			for _, group := range tt.groupFlag {
 				groupMap[group] = true
 			}
-			if got, msg := validateReleaseCharts(tt.args.apps); got != tt.want {
-				t.Errorf("validateReleaseCharts() = %v, want %v , msg: %v", got, tt.want, msg)
+			err := validateReleaseCharts(tt.args.apps)
+			switch err.(type) {
+			case nil:
+				if tt.want != true {
+					t.Errorf("validateReleaseCharts() = %v, want error", err)
+				}
+			case error:
+				if tt.want != false {
+					t.Errorf("validateReleaseCharts() = %v, want nil", err)
+				}
 			}
 		})
 	}
@@ -448,9 +456,16 @@ func Test_eyamlSecrets(t *testing.T) {
 			settings.EyamlEnabled = tt.args.s.EyamlEnabled
 			settings.EyamlPublicKeyPath = tt.args.s.EyamlPublicKeyPath
 			settings.EyamlPrivateKeyPath = tt.args.s.EyamlPrivateKeyPath
-			got := decryptSecret(tt.args.r.SecretsFile)
-			if got != tt.want {
-				t.Errorf("decryptSecret() = %v, want %v", got, tt.want)
+			err := decryptSecret(tt.args.r.SecretsFile)
+			switch err.(type) {
+			case nil:
+				if tt.want != true {
+					t.Errorf("decryptSecret() = %v, want error", err)
+				}
+			case error:
+				if tt.want != false {
+					t.Errorf("decryptSecret() = %v, want nil", err)
+				}
 			}
 			if _, err := os.Stat(tt.args.r.SecretsFile + ".dec"); err == nil {
 				defer deleteFile(tt.args.r.SecretsFile + ".dec")

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -88,8 +88,8 @@ func Main() {
 
 	if !skipValidation {
 		// validate charts-versions exist in defined repos
-		if r, msg := validateReleaseCharts(s.Apps); !r {
-			log.Fatal(msg)
+		if err := validateReleaseCharts(s.Apps); err != nil {
+			log.Fatal(err.Error())
 		}
 	} else {
 		log.Info("Skipping charts' validation.")


### PR DESCRIPTION
Since plan (aka. diffing) is on a second place of time execution right after charts installation/upgrade, I'm adding goroutines to diffing and checking charts availability to improve this part a bit.
Fixed tests and checked that locally, but I'd like someone else to confirm it's ok before it lands in master.