### PR TITLE
Don't remove untracked releasees from namespaces not tracked by the current desired state

### DIFF
--- a/internal/app/decision_maker.go
+++ b/internal/app/decision_maker.go
@@ -184,6 +184,11 @@ func (cs *currentState) getHelmsmanReleases(s *state) map[string]map[string]bool
 		if _, ok := releases[ns]; !ok {
 			releases[ns] = make(map[string]bool)
 		}
+		if !s.isNamespaceDefined(ns) {
+			// if the namespace is not managed by this desired state we assume it's tracked
+			releases[ns][name] = true
+			continue
+		}
 		if rctx != s.Context {
 			// if the release is not related to the current context we assume it's tracked
 			releases[ns][name] = true
@@ -193,6 +198,7 @@ func (cs *currentState) getHelmsmanReleases(s *state) map[string]map[string]bool
 		for _, app := range s.Apps {
 			if app.Name == name && app.Namespace == ns {
 				releases[ns][name] = true
+				break
 			}
 		}
 	}

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -77,7 +77,7 @@ func (r *release) validate(appLabel string, names map[string]map[string]bool, s 
 
 	if flags.nsOverride == "" && r.Namespace == "" {
 		return errors.New("release targeted namespace can't be empty.")
-	} else if flags.nsOverride == "" && r.Namespace != "" && r.Namespace != "kube-system" && !s.checkNamespaceDefined(r.Namespace) {
+	} else if flags.nsOverride == "" && r.Namespace != "" && r.Namespace != "kube-system" && !s.isNamespaceDefined(r.Namespace) {
 		return errors.New("release " + r.Name + " is using namespace [ " + r.Namespace + " ] which is not defined in the Namespaces section of your desired state file." +
 			" Release [ " + r.Name + " ] can't be installed in that Namespace until its defined.")
 	}

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -181,8 +181,8 @@ func isValidCert(value string) (bool, string) {
 	return true, value
 }
 
-// checkNamespaceDefined checks if a given namespace is defined in the namespaces section of the desired state file
-func (s *state) checkNamespaceDefined(ns string) bool {
+// isNamespaceDefined checks if a given namespace is defined in the namespaces section of the desired state file
+func (s *state) isNamespaceDefined(ns string) bool {
 	_, ok := s.Namespaces[ns]
 	return ok
 }


### PR DESCRIPTION
My previous PR ( #353 ) changed the behaviour around cleaning untracked releases, I think it's safer to keep the previous behaviour where we only consider untracked releases for the namespaces being managed by the current desired state, many people I know use per namespace desired states, this would force them to start using the new context feature but migration could be tricky.