### PR TITLE
Fix for matching wrong version on local charts

### DIFF
--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -157,7 +157,7 @@ func validateReleaseCharts(s *state) error {
 	return nil
 }
 
-var versionExtractor = regexp.MustCompile(`version:\s?(.*)`)
+var versionExtractor = regexp.MustCompile(`[\n]version:\s?(.*)`)
 
 func (r *release) validateChart(app string, s *state, wg *sync.WaitGroup, c chan string) {
 


### PR DESCRIPTION
I think this is the fix for the issue mentioned below, unsure if this is dirty or not.
I'm not too sure why we are not parsing it as YAML?

https://github.com/Praqma/helmsman/issues/362