### PR TITLE
deprecate some cmd flags

### DIFF
--- a/docs/cmd_reference.md
+++ b/docs/cmd_reference.md
@@ -1,5 +1,5 @@
 ---
-version: v3.0.0-beta5
+version: v3.0.0-beta6
 ---
 
 # CMD reference
@@ -12,7 +12,10 @@ This lists available CMD options in Helmsman:
         apply the plan directly.
 
   `--debug`
-        show execution logs.
+        show the debug execution logs and actual helm/kubectl commands. This can log secrets and should only be used for debugging purposes.
+
+  `--verbose`
+        show verbose execution logs.   
 
   `--destroy`
         delete all deployed releases.
@@ -50,8 +53,8 @@ This lists available CMD options in Helmsman:
   `--no-env-subst`
         turn off environment substitution globally.
 
-  `--no-env-values-subst`
-        turn off environment substitution in values files only. (default true).
+  `--subst-env-values`
+        turn on environment substitution in values files.
 
   `--no-fancy`
         don't display the banner and don't use colors.
@@ -59,11 +62,11 @@ This lists available CMD options in Helmsman:
   `--no-ns`
         don't create namespaces.
 
-  `-no-ssm-subst`
+  `--no-ssm-subst`
         turn off SSM parameter substitution globally.
 
-  `-no-ssm-values-subst`
-        turn off SSM parameter substitution in values files only (default true).
+  `--subst-ssm-values`
+        turn on SSM parameter substitution in values files.
 
   `--ns-override string`
         override defined namespaces with this one.
@@ -73,9 +76,6 @@ This lists available CMD options in Helmsman:
 
   `--skip-validation`
         skip desired state validation.
-
-  `--suppress-diff-secrets`
-        don't show secrets in helm diff output. (default true).
 
   `--target`
         limit execution to specific app.
@@ -87,6 +87,3 @@ This lists available CMD options in Helmsman:
         run 'helm dep up' for local chart
 
   `--v`    show the version.
-
-  `--verbose`
-        show verbose execution logs.

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -262,15 +262,12 @@ func (r *release) uninstall(p *plan) {
 func (r *release) diff() string {
 	colorFlag := ""
 	diffContextFlag := []string{}
-	suppressDiffSecretsFlag := ""
+	suppressDiffSecretsFlag := "--suppress-secrets"
 	if flags.noColors {
 		colorFlag = "--no-color"
 	}
 	if flags.diffContext != -1 {
 		diffContextFlag = []string{"--context", strconv.Itoa(flags.diffContext)}
-	}
-	if flags.suppressDiffSecrets {
-		suppressDiffSecretsFlag = "--suppress-secrets"
 	}
 
 	cmd := helmCmd(concat([]string{"diff", colorFlag, suppressDiffSecretsFlag}, diffContextFlag, r.getHelmArgsFor("upgrade")), "Diffing release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ]")

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -168,10 +168,10 @@ func substituteVarsInYaml(file string) string {
 	}
 
 	yamlFile := string(rawYamlFile)
-	if !flags.noEnvSubst && !flags.noEnvValuesSubst {
+	if !flags.noEnvSubst && flags.substEnvValues {
 		yamlFile = substituteEnv(yamlFile)
 	}
-	if !flags.noSSMSubst && !flags.noSSMValuesSubst {
+	if !flags.noSSMSubst && flags.substSSMValues {
 		yamlFile = substituteSSM(yamlFile)
 	}
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,4 +1,4 @@
-# v3.0.0-beta5
+# v3.0.0-beta6
 
 This is a major release to support Helm v3.
 It is recommended you read the [Helm 3 migration guide](https://helm.sh/docs/topics/v2_v3_migration/) before using this release.
@@ -8,12 +8,12 @@ It is recommended you read the [Helm 3 migration guide](https://helm.sh/docs/top
 The following are the most important changes:
 - A new and improved logger.
 - Restructuring the code.
-- Parallelized decision making
+- Parallelized decision making.
 - Introducing the `context` stanza to define a context for each DSF. More details [here](docs/misc/merge_desired_state_files).
 - Deprecating all the DSF stanzas related to Tiller.
 - Deprecating the `purge` option for releases.
 - The default value for `storageBackend` is now `secret`.
-- The `--suppress-diff-secrets` cmd flag is enabled by default.
-- The `--no-env-values-subst` cmd flag is enabled by default.
-- The `--no-ssm-values-subst` cmd flag is enabled by default.
+- The `--suppress-diff-secrets` is deprecated. Diff secrets are suppressed by default.
+- The `--no-env-values-subst` cmd flag is deprecated. Env vars substitution in values files is disabled by default. `--subst-env-values` is introduced to enable it when needed. 
+- The `--no-ssm-values-subst` cmd flag is deprecated. SSM vars substitution in values files is disabled by default. `--subst-ssm-values` is introduced to enable it when needed. 
 


### PR DESCRIPTION
This PR deprecates some cmd flags that were enabled by default in v3.0.0-betaX and replaces them with options to do the opposite behaviour.

Namely, the deprecated flags are:

```
--suppress-diff-secrets (no opposite behaviour flag introduced since it's unlikely to be used)
--no-env-values-subst
--no-ssm-values-subst
```
The introduced flags are:
```
--subst-env-values
--subst-ssm-values
```