### PR TITLE
Add backup helmTime parse layout with doubled timezone offset

### DIFF
--- a/internal/app/helm_time.go
+++ b/internal/app/helm_time.go
@@ -7,7 +7,7 @@ import (
 )
 
 const ctLayout = "2006-01-02 15:04:05.000000000 -0700 MST"
-
+const ctLayout2 = "2006-01-02 15:04:05.000000000 -0700 -0700"
 var nilTime = (time.Time{}).UnixNano()
 
 type HelmTime struct {
@@ -29,6 +29,9 @@ func (ht *HelmTime) UnmarshalJSON(b []byte) (err error) {
 	}
 	s = fmt.Sprintf("%s %s.%s %s %s", updatedFields[0], updatedHour[0], milliseconds, updatedFields[2], updatedFields[3])
 	ht.Time, err = time.Parse(ctLayout, s)
+	if err != nil {
+		ht.Time, err = time.Parse(ctLayout2, s)
+	}
 	return
 }
 


### PR DESCRIPTION
Fixes #392 

It just adds backup parse layout until helm updated date issue is explained or fixed (whatever is right).