### PR TITLE
Enhance -target flag to ignore all releases states not targeted 

### DIFF
--- a/internal/app/helm_release.go
+++ b/internal/app/helm_release.go
@@ -40,7 +40,7 @@ func getHelmReleases(s *state) []helmRelease {
 			var releases []helmRelease
 			var targetReleases []helmRelease
 			defer wg.Done()
-			cmd := helmCmd([]string{"list", "--all", "--max", "0", "--output", "json", "-n", ns}, "Listing all existing releases...")
+			cmd := helmCmd([]string{"list", "--all", "--max", "0", "--output", "json", "-n", ns}, "Listing all existing releases in [ "+ns+" ] namespace...")
 			result := cmd.exec()
 			if result.code != 0 {
 				log.Fatal("Failed to list all releases: " + result.errors)
@@ -48,10 +48,14 @@ func getHelmReleases(s *state) []helmRelease {
 			if err := json.Unmarshal([]byte(result.output), &releases); err != nil {
 				log.Fatal(fmt.Sprintf("failed to unmarshal Helm CLI output: %s", err))
 			}
-			for _, r := range releases {
-				if use, ok := s.TargetMap[r.Name]; ok && use {
-					targetReleases = append(targetReleases, r)
+			if len(s.TargetMap) > 0 {
+				for _, r := range releases {
+					if use, ok := s.TargetMap[r.Name]; ok && use {
+						targetReleases = append(targetReleases, r)
+					}
 				}
+			} else {
+				targetReleases = releases
 			}
 			mutex.Lock()
 			allReleases = append(allReleases, targetReleases...)

--- a/internal/app/helm_release.go
+++ b/internal/app/helm_release.go
@@ -27,12 +27,18 @@ func getHelmReleases(s *state) []helmRelease {
 		allReleases []helmRelease
 		wg          sync.WaitGroup
 		mutex       = &sync.Mutex{}
+		namespaces  map[string]namespace
 	)
-
-	for ns := range s.Namespaces {
+	if len(s.TargetMap) > 0 {
+		namespaces = s.TargetNamespaces
+	} else {
+		namespaces = s.Namespaces
+	}
+	for ns := range namespaces {
 		wg.Add(1)
 		go func(ns string) {
 			var releases []helmRelease
+			var targetReleases []helmRelease
 			defer wg.Done()
 			cmd := helmCmd([]string{"list", "--all", "--max", "0", "--output", "json", "-n", ns}, "Listing all existing releases...")
 			result := cmd.exec()
@@ -42,8 +48,13 @@ func getHelmReleases(s *state) []helmRelease {
 			if err := json.Unmarshal([]byte(result.output), &releases); err != nil {
 				log.Fatal(fmt.Sprintf("failed to unmarshal Helm CLI output: %s", err))
 			}
+			for _, r := range releases {
+				if use, ok := s.TargetMap[r.Name]; ok && use {
+					targetReleases = append(targetReleases, r)
+				}
+			}
 			mutex.Lock()
-			allReleases = append(allReleases, releases...)
+			allReleases = append(allReleases, targetReleases...)
 			mutex.Unlock()
 		}(ns)
 	}

--- a/internal/app/kube_helpers.go
+++ b/internal/app/kube_helpers.go
@@ -13,8 +13,14 @@ import (
 // addNamespaces creates a set of namespaces in your k8s cluster.
 // If a namespace with the same name exists, it will skip it.
 // If --ns-override flag is used, it only creates the provided namespace in that flag
-func addNamespaces(namespaces map[string]namespace) {
+func addNamespaces(s state) {
 	var wg sync.WaitGroup
+	var namespaces map[string]namespace
+	if len(s.TargetMap) > 0 {
+		namespaces = s.TargetNamespaces
+	} else {
+		namespaces = s.Namespaces
+	}
 	for nsName, ns := range namespaces {
 		wg.Add(1)
 		go func(name string, cfg namespace, wg *sync.WaitGroup) {

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -32,6 +32,10 @@ func Main() {
 	defer s.cleanup()
 
 	flags.readState(&s)
+	if len(s.TargetMap) > 0 {
+		s.TargetApps = s.getAppsInTargetsOnly()
+		s.TargetNamespaces = s.getNamespacesInTargetsOnly()
+	}
 	settings = s.Settings
 	curContext = s.Context
 
@@ -56,7 +60,7 @@ func Main() {
 		if !flags.noNs {
 			log.Info("Setting up namespaces...")
 			if flags.nsOverride == "" {
-				addNamespaces(s.Namespaces)
+				addNamespaces(s)
 			} else {
 				createNamespace(flags.nsOverride)
 				s.overrideAppsNamespace(flags.nsOverride)

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -142,10 +142,16 @@ func (r *release) validate(appLabel string, names map[string]map[string]bool, s 
 // This function uses Helm search to verify if the chart can be found or not.
 func validateReleaseCharts(s *state) error {
 	var fail bool
+	var apps map[string]*release
 	wg := sync.WaitGroup{}
 	sem := make(chan struct{}, resourcePool)
-	c := make(chan string, len(s.Apps))
-	for app, r := range s.Apps {
+	if len(s.TargetMap) > 0 {
+		apps = s.TargetApps
+	} else {
+		apps = s.Apps
+	}
+	c := make(chan string, len(apps))
+	for app, r := range apps {
 		sem <- struct{}{}
 		wg.Add(1)
 		go func(r *release, app string) {

--- a/internal/app/release_test.go
+++ b/internal/app/release_test.go
@@ -478,8 +478,14 @@ func Test_validateReleaseCharts(t *testing.T) {
 			stt.Apps = tt.args.apps
 			stt.TargetMap = make(map[string]bool)
 			stt.GroupMap = make(map[string]bool)
+			stt.TargetApps = make(map[string]*release)
 			for _, target := range tt.targetFlag {
 				stt.TargetMap[target] = true
+			}
+			for name, use := range stt.TargetMap {
+				if value, ok := stt.Apps[name]; ok && use {
+					stt.TargetApps[name] = value
+				}
 			}
 			for _, group := range tt.groupFlag {
 				stt.GroupMap[group] = true

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -38,6 +38,8 @@ type state struct {
 	AppsTemplates          map[string]*release  `yaml:"appsTemplates,omitempty"`
 	TargetMap              map[string]bool
 	GroupMap               map[string]bool
+	TargetApps             map[string]*release
+	TargetNamespaces       map[string]namespace
 }
 
 // invokes either yaml or toml parser considering file extension
@@ -193,6 +195,31 @@ func (s *state) overrideAppsNamespace(newNs string) {
 	for _, r := range s.Apps {
 		r.overrideNamespace(newNs)
 	}
+}
+
+// get only those Apps that exist in TargetMap
+func (s *state) getAppsInTargetsOnly() map[string]*release {
+	targetApps := make(map[string]*release)
+	for appName, use := range s.TargetMap {
+		if use {
+			if value, ok := s.Apps[appName]; ok {
+				targetApps[appName] = value
+			}
+		}
+	}
+	return targetApps
+}
+
+func (s *state) getNamespacesInTargetsOnly() map[string]namespace {
+	targetNamespaces := make(map[string]namespace)
+	for appName, use := range s.TargetMap {
+		if use {
+			if value, ok := s.Apps[appName]; ok {
+				targetNamespaces[value.Namespace] = s.Namespaces[value.Namespace]
+			}
+		}
+	}
+	return targetNamespaces
 }
 
 // print prints the desired state


### PR DESCRIPTION
This should shorten time needed for targeted deployments as it does not waste time for checking namespaces, charts availability and current state of releases not included in -target flag.