### PR TITLE
Reuse -target flag flow for -group passed

### DIFF
--- a/internal/app/helm_helpers.go
+++ b/internal/app/helm_helpers.go
@@ -12,10 +12,9 @@ import (
 )
 
 type helmRepo struct {
-	Name            string   `json:"name"`
-	Url             string   `json:"url"`
+	Name string `json:"name"`
+	Url  string `json:"url"`
 }
-
 
 // helmCmd prepares a helm command to be executed
 func helmCmd(args []string, desc string) command {
@@ -93,7 +92,7 @@ func addHelmRepos(repos map[string]string) error {
 			existingRepos[repo.Name] = repo.Url
 		}
 	} else {
-		if !strings.Contains(reposResult.errors,"no repositories to show") {
+		if !strings.Contains(reposResult.errors, "no repositories to show") {
 			return fmt.Errorf("while listing helm repositories: %s", reposResult.errors)
 		}
 	}

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -32,6 +32,9 @@ func Main() {
 	defer s.cleanup()
 
 	flags.readState(&s)
+	if len(s.GroupMap) > 0 {
+		s.TargetMap = s.getAppsInGroupsAsTargetMap()
+	}
 	if len(s.TargetMap) > 0 {
 		s.TargetApps = s.getAppsInTargetsOnly()
 		s.TargetNamespaces = s.getNamespacesInTargetsOnly()

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -34,10 +34,18 @@ func Main() {
 	flags.readState(&s)
 	if len(s.GroupMap) > 0 {
 		s.TargetMap = s.getAppsInGroupsAsTargetMap()
+		if len(s.TargetMap) == 0 {
+			log.Info("No apps defined with -group flag were found, exiting...")
+			os.Exit(0)
+		}
 	}
 	if len(s.TargetMap) > 0 {
 		s.TargetApps = s.getAppsInTargetsOnly()
 		s.TargetNamespaces = s.getNamespacesInTargetsOnly()
+		if len(s.TargetApps) == 0 {
+			log.Info("No apps defined with -target flag were found, exiting...")
+			os.Exit(0)
+		}
 	}
 	settings = s.Settings
 	curContext = s.Context

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -55,12 +55,6 @@ func (r *release) isConsideredToRun(s *state) bool {
 		}
 		return false
 	}
-	if len(s.GroupMap) > 0 {
-		if _, ok := s.GroupMap[r.Group]; ok {
-			return true
-		}
-		return false
-	}
 	return true
 }
 

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -197,6 +197,16 @@ func (s *state) overrideAppsNamespace(newNs string) {
 	}
 }
 
+func (s *state) getAppsInGroupsAsTargetMap() map[string]bool {
+	targetApps := make(map[string]bool)
+	for appName, data := range s.Apps {
+		if use, ok := s.GroupMap[data.Group]; ok && use {
+			targetApps[appName] = true
+		}
+	}
+	return targetApps
+}
+
 // get only those Apps that exist in TargetMap
 func (s *state) getAppsInTargetsOnly() map[string]*release {
 	targetApps := make(map[string]*release)


### PR DESCRIPTION
I'm taking advantage of -target limited actions flow merged with #405

When this is merged, I'd like to release 3.1.0, because latest commits introduced some significant enhancements with targets/groups and helm repos