### PR TITLE
Fix proposal for issue #400

### DIFF
--- a/internal/app/helm_helpers.go
+++ b/internal/app/helm_helpers.go
@@ -37,7 +37,7 @@ func extractChartName(releaseChart string) string {
 	for _, v := range strings.Split(result.output, "\n") {
 		split := strings.Split(v, ":")
 		if len(split) == 2 && split[0] == "name" {
-			name = strings.TrimSpace(split[1])
+			name = strings.Trim(split[1], `"' `)
 			break
 		}
 	}


### PR DESCRIPTION
Hello :)

This is a fix proposal for issue #400 

Chart name in DSF file can be a chart from a repository, a path to a local directory or a TGZ archive.
DSF file is currently not idempotent when using a path to a TGZ archive or a path to a local directory where the directory name is different from the chart name because it rely on a regex on the chart name field to get the chart name.

When the chart name is a path to a TGZ archive, the extracted chart name will always be wrong. When it's a local directory, the chart name will be wrong if the directory name is differont from the chart name defined in Chart.yaml.

This PR is a proposal to fix these two issues by executing "helm show chart" and getting chart name from the command output instead of using a regex on the provided chart name in DSF file. This way, the extracted chart name is correct in all cases.