### PR TITLE
Override getContext operation for faster deployments

### DIFF
--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -50,6 +50,7 @@ type cli struct {
 	noFancy               bool
 	noNs                  bool
 	nsOverride            string
+	contextOverride       string
 	skipValidation        bool
 	keepUntrackedReleases bool
 	showDiff              bool
@@ -82,6 +83,7 @@ func (c *cli) parse() {
 	flag.IntVar(&c.diffContext, "diff-context", -1, "number of lines of context to show around changes in helm diff output")
 	flag.StringVar(&c.kubeconfig, "kubeconfig", "", "path to the kubeconfig file to use for CLI requests")
 	flag.StringVar(&c.nsOverride, "ns-override", "", "override defined namespaces with this one")
+	flag.StringVar(&c.contextOverride, "context-override", "", "override releases context with this one")
 	flag.BoolVar(&c.apply, "apply", false, "apply the plan directly")
 	flag.BoolVar(&c.dryRun, "dry-run", false, "apply the dry-run option for helm commands.")
 	flag.BoolVar(&c.destroy, "destroy", false, "delete all deployed releases.")

--- a/internal/app/decision_maker.go
+++ b/internal/app/decision_maker.go
@@ -41,7 +41,12 @@ func buildState(s *state) *currentState {
 				// release
 				<-sem
 			}()
-			r.HelmsmanContext = getReleaseContext(r.Name, r.Namespace)
+			if flags.contextOverride == "" {
+				r.HelmsmanContext = getReleaseContext(r.Name, r.Namespace)
+			} else {
+				log.Info("Overriding Helmsman context for " + r.Name + " as " + flags.contextOverride)
+				r.HelmsmanContext = flags.contextOverride
+			}
 			cs.releases[r.key()] = r
 		}(r)
 	}
@@ -126,7 +131,7 @@ func (cs *currentState) decide(r *release, s *state, p *plan) {
 				"you remove its protection.", r.Priority, noop)
 		}
 	} else if ok := cs.releaseExists(r, helmStatusPending); ok {
-		log.Error("Release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is in pending-upgrade state. " +
+		log.Error("Release [ " + r.Name + " ] in namespace [ " + r.Namespace + " ] is in pending-upgrade state. " +
 			"This means application is being upgraded outside of this Helmsman invocation's scope." +
 			"Exiting, as this may cause issues when continuing...")
 		os.Exit(1)


### PR DESCRIPTION
On large deployments (> 200 releases) the buildState function can be quite long due to a lot of calls to getReleaseContext.

This workaround drastically reduces the buildState time by allowing to bypass the getReleaseContext by assigning a user provided context to every releases.

This is a workaround that can only be used in some specific situations where we know that there would not be any conflicts between contexts.