### PR TITLE
fix namespace limits from toml dsf

### DIFF
--- a/internal/app/namespace.go
+++ b/internal/app/namespace.go
@@ -17,7 +17,7 @@ type limits []struct {
 	Default              resources `yaml:"default,omitempty"`
 	DefaultRequest       resources `yaml:"defaultRequest,omitempty"`
 	MaxLimitRequestRatio resources `yaml:"maxLimitRequestRatio,omitempty"`
-	LimitType            string    `yaml:"type"`
+	Type                 string    `yaml:"type"`
 }
 
 // namespace type represents the fields of a namespace


### PR DESCRIPTION
defining namespace limits in a toml formatted DSF fails due to the `type` being lost in marshalling/unmarshalling. This PR fixes this issue.