### PR TITLE
support overriding helmsman contexts and enable smooth migration of helm 2 to 3  

### DIFF
--- a/docs/cmd_reference.md
+++ b/docs/cmd_reference.md
@@ -41,6 +41,9 @@ This lists available CMD options in Helmsman:
   `--kubeconfig`
         path to the kubeconfig file to use for CLI requests.
 
+  `--migrate-context`
+        Updates the context name for all apps defined in the DSF and applies Helmsman labels. Using this flag is required if you want to change context name after it has been set.      
+
   `--no-banner`
         don't show the banner.
 

--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -1,5 +1,5 @@
 ---
-version: v3.0.0
+version: v3.2.0
 ---
 
 # Helmsman desired state specification
@@ -80,6 +80,8 @@ certificates:
 Optional : Yes.
 
 Synopsis: defines the context in which a DSF is used. This context is used as the ID of that specific DSF and must be unique across the used DSFs. If not defined, `default` is used. Check [here](how_to/misc/merge_desired_state_files.md) for more details on the limitations.
+
+> Renaming the Helmsman context can be done from v3.2.0 using the `--migrate-context` flag. Check [this guide](how_to/apps/migrate_contexts.md) for details.
 
 ```yaml
 context: prod-apps

--- a/docs/how_to/README.md
+++ b/docs/how_to/README.md
@@ -5,6 +5,8 @@ This page contains a list of guides on how to use Helmsman.
 
 It is recommended that you also check the [DSF spec](../desired_state_specification.md), [cmd reference](../cmd_reference.md), and the [best practice guide](../best_practice.md).
 
+- [Migrating from Helm 2 (Helmsman v1.x) to Helm 3 (Helmsman v3.x)](misc/migrate_to_3.md)
+
 - Connecting to Kubernetes clusters
     - [Using an existing kube context](settings/existing_kube_context.md)
     - [Using the current kube context](settings/current_kube_context.md)
@@ -32,6 +34,9 @@ It is recommended that you also check the [DSF spec](../desired_state_specificat
     - [Run helm tests for deployed releases (apps)](apps/helm_tests.md)
     - [Define the order of apps operations](apps/order.md)
     - [Delete all releases (apps)](apps/destroy.md)
+    - [Distinguish releases deployed from different DSF files using Helmsman's contexts](misc/merge_desired_state_files.md#distinguishing-releases-deployed-from-different-desired-state-files)
+    - [Migrating releases from Helmsman context to another](apps/migrate_contexts.md)
+    - [Rename Helmsman's contexts](apps/migrate_contexts.md)
 - Running Helmsman in different environments
     - [Running Helmsman in CI](deployments/ci.md)
     - [Running Helmsman inside your k8s cluster](deployments/inside_k8s.md)

--- a/docs/how_to/apps/migrate_contexts.md
+++ b/docs/how_to/apps/migrate_contexts.md
@@ -1,0 +1,15 @@
+---
+version: v3.2.0
+---
+
+# Migrating releases from Helmsman context to another
+
+The `context` stanza has been introduced in v3.0.0 to allow you to [distinguish releases managed by different Helmsman's files](misc/merge_desired_state_files.md#distinguishing-releases-deployed-from-different-desired-state-files). However, once a context is defined, it couldn't be modified. 
+
+From v.3.2.0, you can migrate releases in a DSF to another context (or rename the context) using the `--migrate-context`. This option can be combined with any other Helmsman flags. Behind the scenes, it will just update the Helmsman labels that contain the context name on the release secrets/configmaps before proceeding with the regular execution.
+
+# Remember
+- It is safe to run the `--migrate-context` flag multiple times.
+- It can be used in conjunction with other cmd flags.
+- It will respect `--target` & `--group` flags if specified (i.e. context migration will only be applied to the selected releases).
+- The flag introduces an extra operation done before any other operations are done. So to reduce execution time, don't use it when it's not needed.

--- a/docs/how_to/misc/merge_desired_state_files.md
+++ b/docs/how_to/misc/merge_desired_state_files.md
@@ -94,10 +94,12 @@ apps:
 ...
 ```
 
+> If you need to migrate releases from one Helmsman's context to another, check this [guide](../apps/migrate_contexts.md).
+
 ### Limitations
 
 - If no context is provided in DSF (or merged DSFs), `default` is applied as a default context. This means any set of DSFs that don't define custom contexts can still operate on each other's releases (same behavior as in Helmsman 1.x).
 
 - When merging multiple DSFs, context from the firs DSF in the list gets overridden by the context in the last DSF.
 
-- If multiple DSFs use the same context name, they will mess up each other's releases.
+- If multiple DSFs use the same context name, they will mess up each other's releases. You can use `--keep-untracked-releases` to avoid that. However, it is recommended to avoid having multiple DSFs using the same context name.

--- a/docs/how_to/misc/migrate_to_3.md
+++ b/docs/how_to/misc/migrate_to_3.md
@@ -1,0 +1,35 @@
+---
+version: v3.2.0
+---
+
+# Migrate from Helm2 (Helmsman v1.x) to Helm3 (Helmsman v3.x)
+
+This guide describes the process of migrating your Helmsman managed releases from Helm v2 to v3.
+Helmsman v3.x is Helm v3-compatible, while Helmsman v1.x is Helm v2-compatible.
+
+The migration process can go as follows: 
+
+## Migrate Helm v2 release state to Helm v3
+- Go through the [Helm's v2 to v3 migration guide](https://helm.sh/docs/topics/v2_v3_migration/)
+- Manually migrate your releases state/history with the [helm3 2to3 plugin](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) (e.g. usage helm3 2to3 convert <helm2-release-name>).
+
+> At this stage, Helm v3 can see and operate on your releases, but Helmsman can't. This is because Helmsman defined labels haven't been migrated to the Helm v3 releases state.
+
+## Migrate to Helmsman v3.x
+- Download the latest Helmsman v3.x release from [Github releases](https://github.com/Praqma/helmsman/releases) 
+- Modify your Helmsman's TOML/YAML desired state files (DSFs) to be Helmsman v3.x compatible. You can check [v3.0.0 release notes](https://github.com/Praqma/helmsman/blob/v3.0.0/release-notes.md) for what's changed and verify from the [Desired State Spec](https://github.com/Praqma/helmsman/blob/master/docs/desired_state_specification.md) that your DSF files are compatible. 
+
+> Everything related to Tiller will be removed from your DSFs at this stage.
+
+- Helmsman v3.x introduces the [`context` stanza](../../desired_state_specification.md#context) to logically group different groups of applications managed by Helmsman. It is highly recommended that you define a unique `context` for each of your DSFs at this stage.
+
+- In order for Helmsman to recognize the Helm v3 releases state, you need to use the `--migrate-context` flag on your first Helmsman v3.x run. This flag will recreate the Helmsman labels needed to recognize the Helm v3 releases state. 
+   - Make sure that `helm` binary points to Helm v3 in your environment before you run this command. 
+   - The `--migrate-context` flag is only available in Helmsman v.3.2.0 and above. If you are using Helmsman v3.0.x or v3.1.x, you can recreate the labels manually or with a script, but we highly recommend using Helmsman v3.2.0 or above.
+   - You only need to use `--migrate-context` once. However, the flag is safe to use multiple times.
+
+   ```bash
+     $ helmsman --debug --migrate-context -f <path-to-your-dsf>.yaml
+   ``` 
+ 
+At this stage, you should have your release migrate to Helm v3 and Helmsman v3.x is able to see and manage those releases as usual. The next step would be to clean up your Helm v2 state and remove Tiller deployment which you can do with the [Helm v3 2to3 plugin](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/). 

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -62,6 +62,7 @@ type cli struct {
 	forceUpgrades         bool
 	version               bool
 	noCleanup             bool
+	migrateContext        bool
 }
 
 func printUsage() {
@@ -103,6 +104,7 @@ func (c *cli) parse() {
 	flag.BoolVar(&c.updateDeps, "update-deps", false, "run 'helm dep up' for local chart")
 	flag.BoolVar(&c.forceUpgrades, "force-upgrades", false, "use --force when upgrading helm releases. May cause resources to be recreated.")
 	flag.BoolVar(&c.noCleanup, "no-cleanup", false, "keeps any credentials files that has been downloaded on the host where helmsman runs.")
+	flag.BoolVar(&c.migrateContext, "migrate-context", false, "Updates the context name for all apps defined in the DSF and applies Helmsman labels. Using this flag is required if you want to change context name after it has been set.")
 	flag.Usage = printUsage
 	flag.Parse()
 

--- a/internal/app/decision_maker.go
+++ b/internal/app/decision_maker.go
@@ -126,7 +126,7 @@ func (cs *currentState) decide(r *release, s *state, p *plan) {
 				"you remove its protection.", r.Priority, noop)
 		}
 	} else if ok := cs.releaseExists(r, helmStatusPending); ok {
-		log.Error("Release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ] is in pending-upgrade state. " +
+		log.Error("Release [ " + r.Name + " ] in namespace [ " + r.Namespace + " ] is in pending-upgrade state. " +
 			"This means application is being upgraded outside of this Helmsman invocation's scope." +
 			"Exiting, as this may cause issues when continuing...")
 		os.Exit(1)

--- a/internal/app/helm_release.go
+++ b/internal/app/helm_release.go
@@ -11,9 +11,9 @@ import (
 
 const (
 	helmStatusDeployed = "deployed"
-	helmStatusDeleted = "deleted"
-	helmStatusFailed = "failed"
-	helmStatusPending = "pending-upgrade"
+	helmStatusDeleted  = "deleted"
+	helmStatusFailed   = "failed"
+	helmStatusPending  = "pending-upgrade"
 )
 
 // helmRelease represents the current state of a release

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -89,11 +89,16 @@ func Main() {
 		log.Info("Skipping charts' validation.")
 	}
 
-	log.Info("Preparing plan...")
 	if flags.destroy {
 		log.Warning("Destroy flag is enabled. Your releases will be deleted!")
 	}
 
+	if flags.migrateContext {
+		log.Warning("migrate-context flag is enabled. Context will be changed to [ " + s.Context + " ] and Helmsman labels will be applied.")
+		s.updateContextLabels()
+	}
+
+	log.Info("Preparing plan...")
 	cs := buildState(&s)
 	p := cs.makePlan(&s)
 	if !flags.keepUntrackedReleases {

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -232,6 +232,18 @@ func (s *state) getNamespacesInTargetsOnly() map[string]namespace {
 	return targetNamespaces
 }
 
+// updateContextLabels applies Helmsman labels including overriding any previously-set context with the one found in the DSF
+func (s *state) updateContextLabels() {
+	for _, r := range s.Apps {
+		if r.isConsideredToRun(s) {
+			log.Info("Updating context and reapplying Helmsman labels for release [ " + r.Name + " ]")
+			r.label()
+		} else {
+			log.Warning(r.Name + " is not in the target group and therefore context and labels are not changed.")
+		}
+	}
+}
+
 // print prints the desired state
 func (s *state) print() {
 


### PR DESCRIPTION
This PR fixes #413 .
It provides two features with one added flag; `--migrate-context`. This flag updates the context labels on the helm releases secrets/configmaps to use whatever context name you have in the DSF.
Additionally, the same flag can be used after migration of helm2 releases to helm3. The 2to3 plugin does not migrate Helmsman labels, thus helmsman can't continue to manage the same releases after they have been migrated. By using the `--migrate-context` flag once, helmsman can recognize those releases again.  

The flag can be used in combination with any other flags and is safe to run multiple times.