### PR TITLE
Fix JSON quoting issues in Slack notifications

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -478,7 +478,7 @@ func notifySlack(content string, url string, failure bool, executing bool) bool 
 				"fallback": "Helmsman results.",
 				"color": "` + color + `" ,
 				"pretext": "` + pretext + `",
-				"title": "` + content + `",
+				"title": ` + strconv.Quote(content) + `,
 				"footer": "Helmsman ` + appVersion + `",
 				"ts": ` + strconv.FormatInt(t.Unix(), 10) + `
 			}


### PR DESCRIPTION
If a call to `notifySlack` passes a string with double quotes in the `content` argument then the webhook fails silently and returns false.

This is because Slack Webhook returns HTTP 400, "invalid_content" due to invalid JSON syntax in the POST request.

Before the fix:
If the `content` was e.g.: `... some text "other text" more text ...`, then the Slack Webhook payload would render an invalid JSON:
```
{
   "attachments": [
        {
            ...
            "title": "... some text "other text" more text ...",
            ...
        }
    ]
}
```

After the fix:
Slack payload for the same `content` would render a valid JSON:
```
{
   "attachments": [
        {
            ...
            "title": "... some text \"other text\" more text ...",
            ...
        }
    ]
}