### PR TITLE
make plan colors a little better on the eyes

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -24,10 +24,10 @@ const (
 )
 
 var decisionColor = map[decisionType]aurora.Color{
-	create:  aurora.BlueFg,
+	create:  aurora.GreenFg,
 	change:  aurora.BrownFg,
 	delete:  aurora.RedFg,
-	noop:    aurora.GreenFg,
+	noop:    aurora.CyanFg,
 	ignored: aurora.GrayFg,
 }
 
@@ -125,7 +125,7 @@ func (p plan) printPlanCmds() {
 // printPlan prints the decisions made in a plan.
 func (p plan) printPlan() {
 	log.Println("----------------------")
-	log.Println(style.Bold(style.Green("INFO: Plan generated at: " + p.Created.Format("Mon Jan _2 2006 15:04:05"))))
+	log.Println(style.Bold(style.Blue("INFO: Plan generated at: " + p.Created.Format("Mon Jan _2 2006 15:04:05"))))
 	for _, decision := range p.Decisions {
 		log.Println(style.Colorize(decision.Description+" -- priority: "+strconv.Itoa(decision.Priority), decisionColor[decision.Type]))
 	}


### PR DESCRIPTION
this pr is just a small attempt to make the plan colors a little easier to read. heres a preview:

![Screenshot_20200417_000032](https://user-images.githubusercontent.com/555966/79531212-a7849380-803f-11ea-84f1-20d5925da6ba.png)

im color blind, so maybe its just me, but  this is way better to pick out the changes/deletions etc from the noops.

thx to @oedmarap for helping me with the colors.