### PR TITLE
Support the Helm --set-file flag

### DIFF
--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -358,6 +358,7 @@ Options:
 - **priority**    : defines the priority of applying operations on this release. Only negative values allowed and the lower the value, the higher the priority. Default priority is 0. Apps with equal priorities will be applied in the order they were added in your state file (DSF).
 - **set**  : is used to override certain values from values.yaml with values from environment variables (or ,starting from v1.3.0-rc, directly provided in the Desired State File). This is particularly useful for passing secrets to charts. If the an environment variable with the same name as the provided value exists, the environment variable value will be used, otherwise, the provided value will be used as is. The TOML stanza for this is `[apps.<app_name>.set]`
 - **setString**   : is used to override String values from values.yaml or chart's defaults. This uses the `--set-string` flag in helm which is available only in helm >v2.9.0. This option is useful for image tags and the like. The TOML stanza for this is `[apps.<app_name>.setString]`
+- **setFile**     : is used to override values from values.yaml or chart's defaults from provided file. This uses the `--set-file` flag in helm. This option is useful for embedding file contents in the values. The TOML stanza for this is `[apps.<app_name>.setFile]`
 - **helmFlags**   : array of `helm` flags, is used to pass flags to helm install/upgrade commands
 
 Example:

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -31,6 +31,7 @@ type release struct {
 	Priority     int               `yaml:"priority"`
 	Set          map[string]string `yaml:"set"`
 	SetString    map[string]string `yaml:"setString"`
+	SetFile      map[string]string `yaml:"setFile"`
 	HelmFlags    []string          `yaml:"helmFlags"`
 	NoHooks      bool              `yaml:"noHooks"`
 	Timeout      int               `yaml:"timeout"`
@@ -461,6 +462,15 @@ func (r *release) getSetStringValues() []string {
 	return result
 }
 
+// getSetFileValues returns --set-file params to be used with helm install/upgrade commands
+func (r *release) getSetFileValues() []string {
+	result := []string{}
+	for k, v := range r.SetFile {
+		result = append(result, "--set-file", k+"="+strings.Replace(v, ",", "\\,", -1)+"")
+	}
+	return result
+}
+
 // getWait returns a partial helm command containing the helm wait flag (--wait) if the wait flag for the release was set to true
 // Otherwise, retruns an empty string
 func (r *release) getWait() []string {
@@ -487,9 +497,9 @@ func (r *release) getHelmFlags() []string {
 func (r *release) getHelmArgsFor(action string) []string {
 	switch action {
 	case "install":
-		return concat([]string{action, r.Name, r.Chart, "--version", r.Version, "--namespace", r.Namespace}, r.getValuesFiles(), r.getSetValues(), r.getSetStringValues(), r.getWait(), r.getHelmFlags())
+		return concat([]string{action, r.Name, r.Chart, "--version", r.Version, "--namespace", r.Namespace}, r.getValuesFiles(), r.getSetValues(), r.getSetStringValues(), r.getSetFileValues(), r.getWait(), r.getHelmFlags())
 	case "upgrade":
-		return concat([]string{action, "--namespace", r.Namespace, r.Name, r.Chart}, r.getValuesFiles(), []string{"--version", r.Version}, r.getSetValues(), r.getSetStringValues())
+		return concat([]string{action, "--namespace", r.Namespace, r.Name, r.Chart}, r.getValuesFiles(), []string{"--version", r.Version}, r.getSetValues(), r.getSetStringValues(), r.getSetFileValues())
 	default:
 		return []string{action, "--namespace", r.Namespace, r.Name}
 	}


### PR DESCRIPTION
As mentioned in https://github.com/Praqma/helmsman/issues/332, I have tried using the `helmFlags` option to add the `--set-file` flag to the Helm install command without success.
So I have created this PR in an attempt to address that issue and add the `setFile` to the list of the available options.
The TOML stanza would be:
```
[apps.<app_name>.setFile]
```
Tested it locally with the built `helmsman` binary and it worked fine.

Signed-off-by: Mehdi Yedes <mehdi.yedes@gmail.com>