### PR TITLE
Performance improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,44 @@ ARG GLOBAL_KUBE_VERSION="v1.14.10"
 ARG GLOBAL_HELM_VERSION="v3.1.1"
 ARG GLOBAL_HELM_DIFF_VERSION="v3.1.1"
 
-
-FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} as builder
+### Helm Installer ###
+FROM alpine:${ALPINE_VERSION} as helm-installer
 ARG GLOBAL_KUBE_VERSION
 ARG GLOBAL_HELM_VERSION
 ARG GLOBAL_HELM_DIFF_VERSION
 ENV KUBE_VERSION=$GLOBAL_KUBE_VERSION
 ENV HELM_VERSION=$GLOBAL_HELM_VERSION
 ENV HELM_DIFF_VERSION=$GLOBAL_HELM_DIFF_VERSION
+
+RUN apk add --update --no-cache ca-certificates git openssh ruby curl tar gzip make bash
+
+RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl
+RUN chmod +x /usr/local/bin/kubectl
+
+RUN curl -Lk https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar zxv -C /tmp
+RUN mv /tmp/linux-amd64/helm /usr/local/bin/helm && rm -rf /tmp/linux-amd64
+RUN chmod +x /usr/local/bin/helm
+
+RUN helm plugin install https://github.com/hypnoglow/helm-s3.git
+RUN helm plugin install https://github.com/nouney/helm-gcs
+RUN helm plugin install https://github.com/databus23/helm-diff --version ${HELM_DIFF_VERSION}
+RUN helm plugin install https://github.com/futuresimple/helm-secrets
+RUN rm -r /tmp/helm-diff /tmp/helm-diff.tgz
+
+### Go Builder & Tester ###
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} as builder
+
+RUN apk add --update --no-cache ca-certificates git openssh ruby bash make
+RUN gem install hiera-eyaml --no-doc
+RUN update-ca-certificates
+
+COPY --from=helm-installer /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=helm-installer /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=helm-installer /root/.cache/helm/plugins/ /root/.cache/helm/plugins/
+COPY --from=helm-installer /root/.local/share/helm/plugins/ /root/.local/share/helm/plugins/
+
 WORKDIR /go/src/github.com/Praqma/helmsman
-COPY scripts/ /tmp/
-RUN sh /tmp/setup.sh \
-    && apk --no-cache add dep
+  
 COPY . .
 RUN make test \
     && LastTag=$(git describe --abbrev=0 --tags) \
@@ -25,14 +51,16 @@ RUN make test \
     && if [ ${LT_SHA} != ${LC_SHA} ]; then TAG=latest-$(date +"%d%m%y"); fi \
     && make build
 
-
+### Final Image ###
 FROM alpine:${ALPINE_VERSION} as base
-ARG GLOBAL_KUBE_VERSION
-ARG GLOBAL_HELM_VERSION
-ARG GLOBAL_HELM_DIFF_VERSION
-ENV KUBE_VERSION=$GLOBAL_KUBE_VERSION
-ENV HELM_VERSION=$GLOBAL_HELM_VERSION
-ENV HELM_DIFF_VERSION=$GLOBAL_HELM_DIFF_VERSION
-COPY scripts/ /tmp/
-RUN sh /tmp/setup.sh
+
+RUN apk add --update --no-cache ca-certificates git openssh ruby curl bash
+RUN gem install hiera-eyaml --no-doc
+RUN update-ca-certificates
+
+COPY --from=helm-installer /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=helm-installer /usr/local/bin/helm /usr/local/bin/helm
+COPY --from=helm-installer /root/.cache/helm/plugins/ /root/.cache/helm/plugins/
+COPY --from=helm-installer /root/.local/share/helm/plugins/ /root/.local/share/helm/plugins/
+
 COPY --from=builder /go/src/github.com/Praqma/helmsman/helmsman /bin/helmsman

--- a/internal/app/decision_maker.go
+++ b/internal/app/decision_maker.go
@@ -58,10 +58,17 @@ func buildState(s *state) *currentState {
 func (cs *currentState) makePlan(s *state) *plan {
 	p := createPlan()
 
+	var apps map[string]*release
+	if len(s.TargetMap) > 0 {
+		apps = s.TargetApps
+	} else {
+		apps = s.Apps
+	}
+
 	wg := sync.WaitGroup{}
 	sem := make(chan struct{}, resourcePool)
-	namesC := make(chan [2]string, len(s.Apps))
-	versionsC := make(chan [4]string, len(s.Apps))
+	namesC := make(chan [2]string, len(apps))
+	versionsC := make(chan [4]string, len(apps))
 
 	// We store the results of the helm commands
 	extractedChartNames := make(map[string]string)
@@ -76,7 +83,7 @@ func (cs *currentState) makePlan(s *state) *plan {
 
 	// Initialize the rejigged data structures
 	charts := make(map[string]map[string]bool)
-	for _, r := range s.Apps {
+	for _, r := range apps {
 		if charts[r.Chart] == nil {
 			charts[r.Chart] = make(map[string]bool)
 		}
@@ -156,7 +163,7 @@ func (cs *currentState) makePlan(s *state) *plan {
 	// Pass the extracted names and versions back to the apps to decide.
 	// We still have to run decide on all the apps, even the ones we previously filtered out when extracting names and versions.
 	// We can now proceed without trying lots of identical helm commands at the same time.
-	for _, r := range s.Apps {
+	for _, r := range apps {
 		// To be honest, the helmCmd function should probably pass back a channel at this point, making the resource pool "global", for all helm commands.
 		// It would make more sense than parallelising *some of the workload* like we do here with r.checkChartDepUpdate(), leaving some helm commands outside the concurrent part.
 		r.checkChartDepUpdate()

--- a/internal/app/decision_maker_test.go
+++ b/internal/app/decision_maker_test.go
@@ -86,7 +86,7 @@ func Test_inspectUpgradeScenario(t *testing.T) {
 		want decisionType
 	}{
 		{
-			name: "makePlan() - local chart with different chart name should change",
+			name: "inspectUpgradeScenario() - local chart with different chart name should change",
 			args: args{
 				r: &release{
 					Name:      "release1",

--- a/internal/app/decision_maker_test.go
+++ b/internal/app/decision_maker_test.go
@@ -86,7 +86,7 @@ func Test_inspectUpgradeScenario(t *testing.T) {
 		want decisionType
 	}{
 		{
-			name: "inspectUpgradeScenario() - local chart with different chart name should change",
+			name: "makePlan() - local chart with different chart name should change",
 			args: args{
 				r: &release{
 					Name:      "release1",
@@ -111,7 +111,9 @@ func Test_inspectUpgradeScenario(t *testing.T) {
 			cs := currentState{releases: *tt.args.s}
 
 			// Act
-			cs.inspectUpgradeScenario(tt.args.r, &outcome)
+			chartName := extractChartName(tt.args.r.Chart)
+			chartVersion, _ := getChartVersion(tt.args.r.Chart, tt.args.r.Version)
+			cs.inspectUpgradeScenario(tt.args.r, &outcome, chartName, chartVersion)
 			got := outcome.Decisions[0].Type
 			t.Log(outcome.Decisions[0].Description)
 
@@ -211,7 +213,7 @@ func Test_decide(t *testing.T) {
 			}
 			outcome := plan{}
 			// Act
-			cs.decide(tt.args.r, tt.args.s, &outcome)
+			cs.decide(tt.args.r, tt.args.s, &outcome, "", "")
 			got := outcome.Decisions[0].Type
 			t.Log(outcome.Decisions[0].Description)
 

--- a/internal/app/helm_helpers.go
+++ b/internal/app/helm_helpers.go
@@ -26,7 +26,7 @@ func helmCmd(args []string, desc string) command {
 
 // extractChartName extracts the Helm chart name from full chart name in the desired state.
 func extractChartName(releaseChart string) string {
-	cmd := helmCmd([]string{"show", "chart", releaseChart}, "Caching chart information for [ "+releaseChart+" ].")
+	cmd := helmCmd([]string{"show", "chart", releaseChart}, "Extracting chart information for [ "+releaseChart+" ].")
 
 	result := cmd.exec()
 	if result.code != 0 {
@@ -54,7 +54,6 @@ func getHelmVersion() string {
 		log.Fatal("While checking helm version: " + result.errors)
 	}
 
-	log.Verbose("Helm version " + result.output)
 	return result.output
 }
 

--- a/internal/app/helm_helpers.go
+++ b/internal/app/helm_helpers.go
@@ -26,7 +26,7 @@ func helmCmd(args []string, desc string) command {
 
 // extractChartName extracts the Helm chart name from full chart name in the desired state.
 func extractChartName(releaseChart string) string {
-	cmd := helmCmd([]string{"show", "chart", releaseChart}, "Extracting chart information for [ "+releaseChart+" ])
+	cmd := helmCmd([]string{"show", "chart", releaseChart}, "Extracting chart information for [ "+releaseChart+" ]")
 
 	result := cmd.exec()
 	if result.code != 0 {

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	helmBin            = "helm"
-	appVersion         = "v3.3.0"
+	appVersion         = "v3.3.1-perf"
 	tempFilesDir       = ".helmsman-tmp"
 	defaultContextName = "default"
 	resourcePool       = 10

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	helmBin            = "helm"
-	appVersion         = "v3.3.1-perf"
+	appVersion         = "v3.3.0"
 	tempFilesDir       = ".helmsman-tmp"
 	defaultContextName = "default"
 	resourcePool       = 10

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -262,9 +262,16 @@ func validateChart(apps, chart, version string, s *state, c chan string) {
 // If chart is local, returns the given release version
 func (r *release) getChartVersion() (string, string) {
 	if isLocalChart(r.Chart) {
+		log.Info("Chart [ " + r.Chart + "] with version [ " + r.Version + " ] was found locally.")
 		return r.Version, ""
 	}
-	cmd := helmCmd([]string{"search", "repo", r.Chart, "--version", r.Version, "-o", "json"}, "Getting latest chart's version "+r.Chart+"-"+r.Version+"")
+
+	if len(r.cachedVersion) > 0 {
+		log.Info("Non-local chart [ " + r.Chart + "] with version [ " + r.Version + " ] was found in cache.")
+		return r.cachedVersion, ""
+	}
+
+	cmd := helmCmd([]string{"search", "repo", r.Chart, "--version", r.Version, "-o", "json"}, "Getting latest non-local chart's version "+r.Chart+"-"+r.Version+"")
 
 	result := cmd.exec()
 	if result.code != 0 {
@@ -288,7 +295,10 @@ func (r *release) getChartVersion() (string, string) {
 	} else if len(filteredChartVersions) > 1 {
 		return "", "Multiple versions of chart [ " + r.Chart + " ] with version [ " + r.Version + " ] found in the helm repositories"
 	}
-	return filteredChartVersions[0].Version, ""
+
+	v := filteredChartVersions[0].Version
+	r.cachedVersion = v
+	return v, ""
 }
 
 // testRelease creates a Helm command to test a particular release.

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -273,13 +273,13 @@ func getChartVersion(chart, version string) (string, string) {
 		return "", "Chart [ " + chart + " ] with version [ " + version + " ] is specified but not found in the helm repositories"
 	}
 
-	cv := make([]chartVersion, 0)
-	if err := json.Unmarshal([]byte(result.output), &cv); err != nil {
+	chartVersions := make([]chartVersion, 0)
+	if err := json.Unmarshal([]byte(result.output), &chartVersions); err != nil {
 		log.Fatal(fmt.Sprint(err))
 	}
 
 	filteredChartVersions := make([]chartVersion, 0)
-	for _, c := range cv {
+	for _, c := range chartVersions {
 		if c.Name == chart {
 			filteredChartVersions = append(filteredChartVersions, c)
 		}

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -173,17 +173,39 @@ func validateReleaseCharts(s *state) error {
 		apps = s.Apps
 	}
 	c := make(chan string, len(apps))
+
+	charts := make(map[string]map[string][]string)
 	for app, r := range apps {
-		sem <- struct{}{}
-		wg.Add(1)
-		go func(r *release, app string) {
-			defer func() {
-				wg.Done()
-				<-sem
-			}()
-			r.validateChart(app, s, c)
-		}(r, app)
+		if charts[r.Chart] == nil {
+			charts[r.Chart] = make(map[string][]string)
+		}
+
+		if charts[r.Chart][r.Version] == nil {
+			charts[r.Chart][r.Version] = make([]string, 0)
+		}
+
+		if r.isConsideredToRun(s) {
+			charts[r.Chart][r.Version] = append(charts[r.Chart][r.Version], app)
+		}
 	}
+
+	for chart, versions := range charts {
+		for version, apps := range versions {
+			concattedApps := strings.Join(apps, ", ")
+			ch := chart
+			v := version
+			sem <- struct{}{}
+			wg.Add(1)
+			go func(apps, chart, version string) {
+				defer func() {
+					wg.Done()
+					<-sem
+				}()
+				validateChart(concattedApps, chart, version, s, c)
+			}(concattedApps, ch, v)
+		}
+	}
+
 	wg.Wait()
 	close(c)
 	for err := range c {
@@ -201,45 +223,37 @@ func validateReleaseCharts(s *state) error {
 var versionExtractor = regexp.MustCompile(`[\n]version:\s?(.*)`)
 
 // validateChart validates if chart with the same name and version as specified in the DSF exists
-func (r *release) validateChart(app string, s *state, c chan string) {
+func validateChart(apps, chart, version string, s *state, c chan string) {
+	if isLocalChart(chart) {
+		cmd := helmCmd([]string{"inspect", "chart", chart}, "Validating [ "+chart+" ] chart's availability")
 
-	validateCurrentChart := true
-	if !r.isConsideredToRun(s) {
-		validateCurrentChart = false
-	}
-	if validateCurrentChart {
-		if isLocalChart(r.Chart) {
-			cmd := helmCmd([]string{"inspect", "chart", r.Chart}, "Validating [ "+r.Chart+" ] chart's availability")
-
-			result := cmd.exec()
-			if result.code != 0 {
-				maybeRepo := filepath.Base(filepath.Dir(r.Chart))
-				c <- "Chart [ " + r.Chart + " ] for app [" + app + "] can't be found. Inspection returned error: \"" +
-					strings.TrimSpace(result.errors) + "\" -- If this is not a local chart, add the repo [ " + maybeRepo + " ] in your helmRepos stanza."
+		result := cmd.exec()
+		if result.code != 0 {
+			maybeRepo := filepath.Base(filepath.Dir(chart))
+			c <- "Chart [ " + chart + " ] for apps [" + apps + "] can't be found. Inspection returned error: \"" +
+				strings.TrimSpace(result.errors) + "\" -- If this is not a local chart, add the repo [ " + maybeRepo + " ] in your helmRepos stanza."
+			return
+		}
+		matches := versionExtractor.FindStringSubmatch(result.output)
+		if len(matches) == 2 {
+			v := strings.Trim(matches[1], `'"`)
+			if strings.Trim(version, `'"`) != v {
+				c <- "Chart [ " + chart + " ] with version [ " + version + " ] is specified for " +
+					"apps [" + apps + "] but the chart found at that path has version [ " + v + " ] which does not match."
 				return
 			}
-			matches := versionExtractor.FindStringSubmatch(result.output)
-			if len(matches) == 2 {
-				version := strings.Trim(matches[1], `'"`)
-				if strings.Trim(r.Version, `'"`) != version {
-					c <- "Chart [ " + r.Chart + " ] with version [ " + r.Version + " ] is specified for " +
-						"app [" + app + "] but the chart found at that path has version [ " + version + " ] which does not match."
-					return
-				}
-			}
+		}
+	} else {
+		v := version
+		if len(v) == 0 {
+			v = "*"
+		}
+		cmd := helmCmd([]string{"search", "repo", chart, "--version", v, "-l"}, "Validating [ "+chart+" ] chart's version [ "+version+" ] availability")
 
-		} else {
-			version := r.Version
-			if len(version) == 0 {
-				version = "*"
-			}
-			cmd := helmCmd([]string{"search", "repo", r.Chart, "--version", version, "-l"}, "Validating [ "+r.Chart+" ] chart's version [ "+r.Version+" ] availability")
-
-			if result := cmd.exec(); result.code != 0 || strings.Contains(result.output, "No results found") {
-				c <- "Chart [ " + r.Chart + " ] with version [ " + r.Version + " ] is specified for " +
-					"app [" + app + "] but was not found. If this is not a local chart, define its helm repo in the helmRepo stanza in your DSF."
-				return
-			}
+		if result := cmd.exec(); result.code != 0 || strings.Contains(result.output, "No results found") {
+			c <- "Chart [ " + chart + " ] with version [ " + version + " ] is specified for " +
+				"apps [" + apps + "] but was not found. If this is not a local chart, define its helm repo in the helmRepo stanza in your DSF."
+			return
 		}
 	}
 }

--- a/internal/app/release_test.go
+++ b/internal/app/release_test.go
@@ -457,10 +457,36 @@ func Test_inheritHooks(t *testing.T) {
 		})
 	}
 }
+
+func createFullReleasePointer(chart, version string) *release {
+	return &release{
+		Name:         "",
+		Description:  "",
+		Namespace:    "",
+		Enabled:      true,
+		Chart:        chart,
+		Version:      version,
+		ValuesFile:   "",
+		ValuesFiles:  []string{},
+		SecretsFile:  "",
+		SecretsFiles: []string{},
+		Test:         false,
+		Protected:    false,
+		Wait:         false,
+		Priority:     0,
+		Set:          make(map[string]string),
+		SetString:    make(map[string]string),
+		HelmFlags:    []string{},
+		NoHooks:      false,
+		Timeout:      0,
+	}
+}
+
 func Test_validateReleaseCharts(t *testing.T) {
 	type args struct {
 		apps map[string]*release
 	}
+
 	tests := []struct {
 		name       string
 		targetFlag []string
@@ -473,27 +499,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 			targetFlag: []string{},
 			args: args{
 				apps: map[string]*release{
-					"app": &release{
-						Name:         "",
-						Description:  "",
-						Namespace:    "",
-						Enabled:      true,
-						Chart:        os.TempDir() + "/helmsman-tests/myapp",
-						Version:      "",
-						ValuesFile:   "",
-						ValuesFiles:  []string{},
-						SecretsFile:  "",
-						SecretsFiles: []string{},
-						Test:         false,
-						Protected:    false,
-						Wait:         false,
-						Priority:     0,
-						Set:          make(map[string]string),
-						SetString:    make(map[string]string),
-						HelmFlags:    []string{},
-						NoHooks:      false,
-						Timeout:      0,
-					},
+					"app": createFullReleasePointer(os.TempDir()+"/helmsman-tests/myapp", ""),
 				},
 			},
 			want: false,
@@ -502,27 +508,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 			targetFlag: []string{},
 			args: args{
 				apps: map[string]*release{
-					"app": &release{
-						Name:         "",
-						Description:  "",
-						Namespace:    "",
-						Enabled:      true,
-						Chart:        os.TempDir() + "/does-not-exist/myapp",
-						Version:      "",
-						ValuesFile:   "",
-						ValuesFiles:  []string{},
-						SecretsFile:  "",
-						SecretsFiles: []string{},
-						Test:         false,
-						Protected:    false,
-						Wait:         false,
-						Priority:     0,
-						Set:          make(map[string]string),
-						SetString:    make(map[string]string),
-						HelmFlags:    []string{},
-						NoHooks:      false,
-						Timeout:      0,
-					},
+					"app": createFullReleasePointer(os.TempDir()+"/does-not-exist/myapp", ""),
 				},
 			},
 			want: false,
@@ -531,27 +517,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 			targetFlag: []string{},
 			args: args{
 				apps: map[string]*release{
-					"app": &release{
-						Name:         "",
-						Description:  "",
-						Namespace:    "",
-						Enabled:      true,
-						Chart:        os.TempDir() + "/helmsman-tests/dir-with space/myapp",
-						Version:      "0.1.0",
-						ValuesFile:   "",
-						ValuesFiles:  []string{},
-						SecretsFile:  "",
-						SecretsFiles: []string{},
-						Test:         false,
-						Protected:    false,
-						Wait:         false,
-						Priority:     0,
-						Set:          make(map[string]string),
-						SetString:    make(map[string]string),
-						HelmFlags:    []string{},
-						NoHooks:      false,
-						Timeout:      0,
-					},
+					"app": createFullReleasePointer(os.TempDir()+"/helmsman-tests/dir-with space/myapp", "0.1.0"),
 				},
 			},
 			want: true,
@@ -560,27 +526,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 			targetFlag: []string{},
 			args: args{
 				apps: map[string]*release{
-					"app": &release{
-						Name:         "",
-						Description:  "",
-						Namespace:    "",
-						Enabled:      true,
-						Chart:        "stable/prometheus",
-						Version:      "9.5.2",
-						ValuesFile:   "",
-						ValuesFiles:  []string{},
-						SecretsFile:  "",
-						SecretsFiles: []string{},
-						Test:         false,
-						Protected:    false,
-						Wait:         false,
-						Priority:     0,
-						Set:          make(map[string]string),
-						SetString:    make(map[string]string),
-						HelmFlags:    []string{},
-						NoHooks:      false,
-						Timeout:      0,
-					},
+					"app": createFullReleasePointer("stable/prometheus", "9.5.2"),
 				},
 			},
 			want: true,
@@ -589,27 +535,7 @@ func Test_validateReleaseCharts(t *testing.T) {
 			targetFlag: []string{"notThisOne"},
 			args: args{
 				apps: map[string]*release{
-					"app": &release{
-						Name:         "app",
-						Description:  "",
-						Namespace:    "",
-						Enabled:      true,
-						Chart:        os.TempDir() + "/does-not-exist/myapp",
-						Version:      "",
-						ValuesFile:   "",
-						ValuesFiles:  []string{},
-						SecretsFile:  "",
-						SecretsFiles: []string{},
-						Test:         false,
-						Protected:    false,
-						Wait:         false,
-						Priority:     0,
-						Set:          make(map[string]string),
-						SetString:    make(map[string]string),
-						HelmFlags:    []string{},
-						NoHooks:      false,
-						Timeout:      0,
-					},
+					"app": createFullReleasePointer(os.TempDir()+"/does-not-exist/myapp", ""),
 				},
 			},
 			want: true,
@@ -618,30 +544,23 @@ func Test_validateReleaseCharts(t *testing.T) {
 			targetFlag: []string{"app"},
 			args: args{
 				apps: map[string]*release{
-					"app": &release{
-						Name:         "app",
-						Description:  "",
-						Namespace:    "",
-						Enabled:      true,
-						Chart:        os.TempDir() + "/does-not-exist/myapp",
-						Version:      "",
-						ValuesFile:   "",
-						ValuesFiles:  []string{},
-						SecretsFile:  "",
-						SecretsFiles: []string{},
-						Test:         false,
-						Protected:    false,
-						Wait:         false,
-						Priority:     0,
-						Set:          make(map[string]string),
-						SetString:    make(map[string]string),
-						HelmFlags:    []string{},
-						NoHooks:      false,
-						Timeout:      0,
-					},
+					"app": createFullReleasePointer(os.TempDir()+"/does-not-exist/myapp", ""),
 				},
 			},
 			want: false,
+		}, {
+			name:       "test case 7: multiple valid local apps with the same chart version",
+			targetFlag: []string{"app"},
+			args: args{
+				apps: map[string]*release{
+					"app1": createFullReleasePointer(os.TempDir()+"/helmsman-tests/dir-with space/myapp", "0.1.0"),
+					"app2": createFullReleasePointer(os.TempDir()+"/helmsman-tests/dir-with space/myapp", "0.1.0"),
+					"app3": createFullReleasePointer(os.TempDir()+"/helmsman-tests/dir-with space/myapp", "0.1.0"),
+					"app4": createFullReleasePointer(os.TempDir()+"/helmsman-tests/dir-with space/myapp", "0.1.0"),
+					"app5": createFullReleasePointer(os.TempDir()+"/helmsman-tests/dir-with space/myapp", "0.1.0"),
+				},
+			},
+			want: true,
 		},
 	}
 
@@ -815,7 +734,7 @@ func Test_getChartVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Log(tt.want)
-			got, _ := tt.args.r.getChartVersion()
+			got, _ := getChartVersion(tt.args.r.Chart, tt.args.r.Version)
 			if got != tt.want {
 				t.Errorf("getChartVersion() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
In short, this PR makes `helmsman` call `helm` less. 

If we have 100 apps, and they are all on the same version of the same chart, helmsman would validate that chart 100 times in a row with identical calls to `helm`. This doesn't need to happen. I kept the idea of running helm commands concurrently a `resourcePool` number of times (more on `resourcePool` vs the `-p` flag later in this comment), but I have expanded it -- we concurrently ask helm about the charts (like we used to), but we only do so once per chart version pair (at least in `makePlan`). 

Compared to my previous PR, I am no longer trying to cache chart names and versions in an atomic `sync.Cache`. Since we went to the OS and called helm a bunch of times concurrently, they'd all check the cache and see the result wasn't there, then all the resources in the pool would attempt to fill the cache by calling the expensive `helm` command at the same time. It was still faster (because I decoupled `validateChart` from the release), but this is faster still.

I've updated the Dockerfile quite a bit too, I don't know if it'll pass CircleCI.

For our use case these changes seem to roughly double the speed of our deploys on helmsman. However, I haven't done any profiling (just a few very quick eyeball tests) and I haven't written any tests that test when there's lots of releases on a mixture of charts.

`resourcePool` now applies slightly differently to makePlan. I suggest we combine `resourcePool` with the `-p` flag so we can set the resourcePool number ourselves and have it apply consistently, but another time I want to look at how the concurrency on helm commands is performing across the board. Some helm commands still aren't run concurrently (like `r.checkChartDepUpdate()` which I haven't looked at yet), and i have no data on what kind of `resourcePool` number might be optimal, but this is a start.

This could definitely be DRYed up and refactored but I think these changes should provide some inroads into making helmsman more performant, especially when someone is deploying a lot of apps that share charts (as we are).
