### PR TITLE
Add gnupg to Docker image

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-apk add --update --no-cache ca-certificates git openssh ruby curl tar gzip make bash
+apk add --update --no-cache ca-certificates git openssh ruby curl tar gzip make bash gnupg
 curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl
 chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
`gnupg` is missing from the helmsman docker image, but it is a dependency for `helm-secrets`.
This PR includes `gnupg` in the list of packages installed during the Docker build.

This solves https://github.com/Praqma/helmsman/issues/448

Signed-off-by: Mehdi Yedes <mehdi.yedes@gmail.com>