### PR TITLE
fix inconsistent helm args between install and upgrade. fixes #451

### DIFF
--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -368,7 +368,7 @@ Options:
 - **set**  : is used to override certain values from values.yaml with values from environment variables (or ,starting from v1.3.0-rc, directly provided in the Desired State File). This is particularly useful for passing secrets to charts. If the an environment variable with the same name as the provided value exists, the environment variable value will be used, otherwise, the provided value will be used as is. The TOML stanza for this is `[apps.<app_name>.set]`
 - **setString**   : is used to override String values from values.yaml or chart's defaults. This uses the `--set-string` flag in helm which is available only in helm >v2.9.0. This option is useful for image tags and the like. The TOML stanza for this is `[apps.<app_name>.setString]`
 - **setFile**     : is used to override values from values.yaml or chart's defaults from provided file. This uses the `--set-file` flag in helm. This option is useful for embedding file contents in the values. The TOML stanza for this is `[apps.<app_name>.setFile]`
-- **helmFlags**   : array of `helm` flags, is used to pass flags to helm install/upgrade commands
+- **helmFlags**   : array of `helm` upgrade flags, is used to pass flags to helm install/upgrade commands. **These flags are not passed to helm diff**. For setting values, use **set**, **setString** or **setFile** instead.
 - **hooks** : defines global lifecycle hooks to apply yaml manifest before and/or after different helmsman operations. Check [here](how_to/apps/lifecycle_hooks.md) for more details. Unset hooks for a release are inherited from `globalHooks` in the [settings](#Settings) stanza.
 
 Example:

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -324,7 +324,7 @@ func (r *release) diff() string {
 		diffContextFlag = []string{"--context", strconv.Itoa(flags.diffContext)}
 	}
 
-	cmd := helmCmd(concat([]string{"diff", colorFlag, suppressDiffSecretsFlag}, diffContextFlag, r.getHelmArgsFor("upgrade")), "Diffing release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ]")
+	cmd := helmCmd(concat([]string{"diff", colorFlag, suppressDiffSecretsFlag}, diffContextFlag, r.getHelmArgsFor("diff")), "Diffing release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ]")
 
 	result := cmd.exec()
 	if result.code != 0 {
@@ -541,10 +541,10 @@ func (r *release) getHelmArgsFor(action string, optionalNamespaceOverride ...str
 		ns = optionalNamespaceOverride[0]
 	}
 	switch action {
-	case "install":
-		return concat([]string{action, r.Name, r.Chart, "--version", r.Version, "--namespace", r.Namespace}, r.getValuesFiles(), r.getSetValues(), r.getSetStringValues(), r.getSetFileValues(), r.getWait(), r.getHelmFlags())
-	case "upgrade":
-		return concat([]string{action, "--namespace", r.Namespace, r.Name, r.Chart}, r.getValuesFiles(), []string{"--version", r.Version}, r.getSetValues(), r.getSetStringValues(), r.getSetFileValues())
+	case "install", "upgrade":
+		return concat([]string{"upgrade", r.Name, r.Chart, "--install", "--version", r.Version, "--namespace", r.Namespace}, r.getValuesFiles(), r.getSetValues(), r.getSetStringValues(), r.getSetFileValues(), r.getWait(), r.getHelmFlags())
+	case "diff":
+		return concat([]string{"upgrade", r.Name, r.Chart, "--version", r.Version, "--namespace", r.Namespace}, r.getValuesFiles(), r.getSetValues(), r.getSetStringValues(), r.getSetFileValues())
 	default:
 		return []string{action, "--namespace", ns, r.Name}
 	}


### PR DESCRIPTION
- Use helm upgrade --install for both helm install and upgrade calls.
- Ensure that helmFlags are passed to both install and upgrade calls and that the same args are passed.
- Split diff arguments to return only helm diff compatible flags. `helmFlags` are not passed to helm diff calls. 
- Update docs to recommend not using `helmFlags` for setting values and to use `set`, `setString` or `setFile` options in the desired state file instead.