### PR TITLE
allow absolute paths for values/secrets/etc files. Fixes #437

### DIFF
--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -352,11 +352,11 @@ Options:
 **Optional**
 - **group**       : group name this apps belongs to. It has no effect until Helmsman's flag `-group` is passed. Check this [doc](how_to/misc/limit-deployment-to-specific-group-of-apps.md) for more details.
 - **description** : a release metadata for human readers.
-- **valuesFile**  : a valid path (URL, cloud bucket, local file path) to custom Helm values.yaml file. File extension must be `yaml`. Cannot be used with valuesFiles together. Leaving it empty uses the default chart values.
-- **valuesFiles** : array of valid paths (URL, cloud bucket, local file path) to custom Helm values.yaml file. File extension must be `yaml`. Cannot be used with valuesFile together. Leaving it empty uses the default chart values.
+- **valuesFile**  : a valid path (URL, cloud bucket, local absolute/relative file path) to custom Helm values.yaml file. File extension must be `yaml`. Cannot be used with valuesFiles together. Leaving it empty uses the default chart values.
+- **valuesFiles** : array of valid paths (URL, cloud bucket, local absolute/relative file path) to custom Helm values.yaml file. File extension must be `yaml`. Cannot be used with valuesFile together. Leaving it empty uses the default chart values.
 > The values file(s) path is resolved when the DSF yaml/toml file is loaded, relative to the path that the dsf was loaded from.
-- **secretsFile**  : a valid path (URL, cloud bucket, local file path) to custom Helm secrets.yaml file. File extension must be `yaml`. Cannot be used with secretsFiles together. Leaving it empty uses the default chart secrets.
-- **secretsFiles** : array of valid paths (URL, cloud bucket, local file path) to custom Helm secrets.yaml file. File extension must be `yaml`. Cannot be used with secretsFile together. Leaving it empty uses the default chart secrets.
+- **secretsFile**  : a valid path (URL, cloud bucket, local absolute/relative file path) to custom Helm secrets.yaml file. File extension must be `yaml`. Cannot be used with secretsFiles together. Leaving it empty uses the default chart secrets.
+- **secretsFiles** : array of valid paths (URL, cloud bucket, local absolute/relative file path) to custom Helm secrets.yaml file. File extension must be `yaml`. Cannot be used with secretsFile together. Leaving it empty uses the default chart secrets.
 > The secrets file(s) path is resolved when the DSF yaml/toml file is loaded, relative to the path that the dsf was loaded from.
 > To use the secrets files you must have the helm-secrets plugin
 - **test**        : defines whether to run the chart tests whenever the release is installed. Default is false.

--- a/docs/how_to/apps/multiple_values_files.md
+++ b/docs/how_to/apps/multiple_values_files.md
@@ -6,6 +6,8 @@ version: v3.3.0-beta1
 
 You can include multiple yaml value files to separate configuration for different environments.
 
+> file paths can be a URL (e.g. to a public git repo) , cloud bucket, local absolute/relative file path.
+
 ```toml
 ...
 [apps]

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -383,8 +383,11 @@ func downloadFile(file string, dir string, outfile string) string {
 
 	} else {
 
-		log.Info("" + outfile + " will be used from local file system.")
-		toCopy, _ := filepath.Abs(filepath.Join(dir, file))
+		log.Info("" + file + " will be used from local file system.")
+		toCopy := file
+		if !filepath.IsAbs(file) {
+			toCopy, _ = filepath.Abs(filepath.Join(dir, file))
+		}
 		copyFile(toCopy, outfile)
 	}
 	return outfile


### PR DESCRIPTION
- Allow absolute paths to be used for values/secrets/etc files.