### PR TITLE
Feature/max history

### DIFF
--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -134,7 +134,8 @@ kubeContext = "minikube"
 # [settings.globalHooks]
 #   successCondition= "Complete"
 #   deleteOnSuccess= true
-#   postInstall= "job.yaml"    
+#   postInstall= "job.yaml"  
+globalMaxHistory= 10  
 ```
 
 ```yaml
@@ -153,7 +154,8 @@ settings:
   # globalHooks:
   #   successCondition: "Complete"
   #   deleteOnSuccess: true
-  #   preInstall: "job.yaml"    
+  #   preInstall: "job.yaml"   
+  globalMaxHistory: 10 
 ```
 
 ## Namespaces

--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -113,6 +113,7 @@ The following options can be skipped if your kubectl context is already created 
 - **eyamlPrivateKeyPath** : if set with path to the eyaml private key file, it will use it instead of looking for default one in ./keys directory relative to where Helmsman were run. It needs to be defined in conjunction with eyamlPublicKeyPath.
 - **eyamlPublicKeyPath** : if set with path to the eyaml public key file, it will use it instead of looking for default one in ./keys directory relative to where Helmsman were run. It needs to be defined in conjunction with eyamlPrivateKeyPath.
 - **globalHooks** : defines global lifecycle hooks to apply yaml manifest before and/or after different helmsman operations. Check [here](how_to/apps/lifecycle_hooks.md) for more details.
+- **globalMaxHistory** : defines the **global** maximum number of helm revisions state (secrets/configmap) to keep. Releases can override this global value by setting `maxHistory`. If both are not set or are set to `0`, it is defaulted to 10.
 
 
 Example:
@@ -370,6 +371,7 @@ Options:
 - **setFile**     : is used to override values from values.yaml or chart's defaults from provided file. This uses the `--set-file` flag in helm. This option is useful for embedding file contents in the values. The TOML stanza for this is `[apps.<app_name>.setFile]`
 - **helmFlags**   : array of `helm` upgrade flags, is used to pass flags to helm install/upgrade commands. **These flags are not passed to helm diff**. For setting values, use **set**, **setString** or **setFile** instead.
 - **hooks** : defines global lifecycle hooks to apply yaml manifest before and/or after different helmsman operations. Check [here](how_to/apps/lifecycle_hooks.md) for more details. Unset hooks for a release are inherited from `globalHooks` in the [settings](#Settings) stanza.
+- **maxHistory** : defines the maximum number of helm revisions state (secrets/configmap) to keep. If unset, it will inherit the value of `settings.globalMaxHistory`, if that's also unset, it defaults to 10.
 
 Example:
 
@@ -388,6 +390,7 @@ Example:
     version = "0.9.0"
     valuesFile = ""
     test = true
+    maxHistory = 4
     protected = false
     wait = true
     priority = -3
@@ -420,6 +423,7 @@ apps:
     version: "0.9.0"
     valuesFile: ""
     test: true
+    maxHistory: 4
     protected: false
     wait: true
     priority: -3

--- a/examples/example.toml
+++ b/examples/example.toml
@@ -36,6 +36,7 @@ context= "test-infra"   # defaults to "default" if not provided
 #     successCondition= "Initialized"
 #     deleteOnSuccess= true
 #     postInstall= "job.yaml"
+  globalMaxHistory= 5
 
 
 
@@ -116,8 +117,8 @@ context= "test-infra"   # defaults to "default" if not provided
   # [apps.argo.setString] # values to override values from values.yaml with values from env vars or directly entered-- useful for passing secrets to charts
   #   AdminPassword="$SOME_PASSWORD" # $SOME_PASSWORD must exist in the environment
   #   MyLongIntVar="1234567890"
-  # [apps.argo.set]
-  #   installCRD="true"
+  [apps.argo.setString]
+    "images.tag"="v2.7.5"
 
 
   [apps.artifactory]
@@ -131,6 +132,10 @@ context= "test-infra"   # defaults to "default" if not provided
     priority= -2
     noHooks= false
     timeout= 300
-    helmFlags= [] # additional helm flags for this release
+    maxHistory = 4
+    # additional helm flags for this release
+    helmFlags= [
+      "--devel",
+    ] 
 
 # See https://github.com/Praqma/helmsman/blob/master/docs/desired_state_specification.md#apps for more apps options

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -1,4 +1,10 @@
 # version: v3.0.0
+
+# context defines the context of this Desired State File.
+# It is used to allow Helmsman identify which releases are managed by which DSF.
+# Therefore, it is important that each DSF uses a unique context.
+context: test-infra   # defaults to "default" if not provided
+
 # metadata -- add as many key/value pairs as you want
 metadata:
   org: "example.com/$ORG_PATH/"
@@ -13,18 +19,13 @@ metadata:
   #caCrt: "s3://mybucket/ca.crt" # S3 bucket path
   #caKey: "../ca.key" # valid local file relative path
 
-# context defines the context of this Desired State File.
-# It is used to allow Helmsman identify which releases are managed by which DSF.
-# Therefore, it is important that each DSF uses a unique context.
-context: test-infra   # defaults to "default" if not provided
-
 settings:
   kubeContext: "minikube" # will try connect to this context first, if it does not exist, it will be created using the details below
   #username: "admin"
   #password: "$K8S_PASSWORD" # the name of an environment variable containing the k8s password
   #clusterURI: "$SET_URI" # the name of an environment variable containing the cluster API
   #clusterURI: "https://192.168.99.100:8443" # equivalent to the above
-  storageBackend: "secret"
+  #storageBackend: "secret"
   #slackWebhook:  "$slack" # or your slack webhook url
   #reverseDelete: false # reverse the priorities on delete
   #### to use bearer token:
@@ -34,6 +35,7 @@ settings:
   #   successCondition: "Initialized"
   #   deleteOnSuccess: true
   #   postInstall: "job.yaml"
+  globalMaxHistory: 5
 
 # define your environments and their k8s namespaces
 namespaces:
@@ -51,9 +53,19 @@ namespaces:
         max:
           memory: "300Mi"
   staging:
-   # protected: false
-    # labels:
-    #   env: "staging"
+    protected: false
+    labels:
+      env: "staging"
+    quotas:
+      limits.cpu: "10"
+      limits.memory: "20Gi"
+      pods: 25
+      requests.cpu: "10"
+      requests.memory: "30Gi"
+      customQuotas:
+        - name: "requests.nvidia.com/gpu"  
+          value: "2"    
+
 
 
 # define any private/public helm charts repos you would like to get charts from
@@ -72,23 +84,22 @@ helmRepos:
 # each contains the following:
 
 apps:
-
     argo:
       namespace: "staging" # maps to the namespace as defined in namespaces above
       enabled: true # change to false if you want to delete this app release empty: false:
       chart: "argo/argo" # changing the chart name means delete and recreate this chart
-      version: "0.6.5" # chart version
+      version: "0.8.5" # chart version
       ### Optional values below
       valuesFile: "" # leaving it empty uses the default chart values
       test: false
       protected: true
       priority: -3
       wait: true
-      # hooks:
-      #   successCondition: "Complete"
-      #   successTimeout: "90s"
-      #   deleteOnSuccess: true
-      #   preInstall: "job.yaml"
+      hooks:
+        successCondition: "Complete"
+        successTimeout: "90s"
+        deleteOnSuccess: true
+        preInstall: "job.yaml"
       #   preInstall: "https://github.com/jetstack/cert-manager/releases/download/v0.14.0/cert-manager.crds.yaml"
       #   postInstall: "https://raw.githubusercontent.com/jetstack/cert-manager/release-0.14/deploy/manifests/00-crds.yaml"
       #   postInstall: "job.yaml"
@@ -108,6 +119,9 @@ apps:
       priority: -2
       noHooks: false
       timeout: 300
-      helmFlags: [] # additional helm flags for this release
+      maxHistory: 4
+      # additional helm flags for this release
+      helmFlags: 
+        - "--devel"
 
 # See https://github.com/Praqma/helmsman/blob/master/docs/desired_state_specification.md#apps for more apps options

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -289,6 +289,7 @@ func (c *cli) readState(s *state) {
 	// inherit globalHooks if local ones are not set
 	for _, r := range s.Apps {
 		r.inheritHooks(s)
+		r.inheritMaxHistory(s)
 	}
 
 	if c.debug {

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -25,6 +25,7 @@ type config struct {
 	EyamlPrivateKeyPath string                 `yaml:"eyamlPrivateKeyPath"`
 	EyamlPublicKeyPath  string                 `yaml:"eyamlPublicKeyPath"`
 	GlobalHooks         map[string]interface{} `yaml:"globalHooks"`
+	GlobalMaxHistory    int                    `yaml:"globalMaxHistory"`
 }
 
 // state type represents the desired state of applications on a k8s cluster.


### PR DESCRIPTION
support for using `--history-max` helm upgrade flag. Fixes #443 

- **globalMaxHistory** : defines the **global** maximum number of helm revisions state (secrets/configmap) to keep. Releases can override this global value by setting `maxHistory`. If both are not set or are set to `0`, it is defaulted to 10.
- **maxHistory** : defines the maximum number of helm revisions state (secrets/configmap) to keep. If unset, it will inherit the value of `settings.globalMaxHistory`, if that's also unset, it defaults to 10.