### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/how_to/apps/lifecycle_hooks.md
+++ b/docs/how_to/apps/lifecycle_hooks.md
@@ -43,7 +43,7 @@ For deployments, it is `Available`
 
 You can define two types of hooks in your desired state file:
 
-- **Gloabl** hooks: are defined in the `settings` stanza and are inherited by all releases in the DSF if they haven't defined their own.
+- **Global** hooks: are defined in the `settings` stanza and are inherited by all releases in the DSF if they haven't defined their own.
 
 These are defined as follows:
 ```toml


### PR DESCRIPTION
Fixing a small typo in the lifecycle hooks docs.

Signed-off-by: Mehdi Yedes <mehdi.yedes@gmail.com>