### PR TITLE
randomize temporary file names

### DIFF
--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -288,8 +288,12 @@ func resolvePaths(relativeToFile string, s *state) {
 // and downloads/fetches the file locally into helmsman temp directory and returns
 // its absolute path
 func resolveOnePath(file string, dir string, downloadDest string) (string, error) {
-	destFileName := filepath.Join(downloadDest, path.Base(file))
-	return filepath.Abs(downloadFile(file, dir, destFileName))
+	if destFile, err := ioutil.TempFile(downloadDest, fmt.Sprintf("*%s", path.Base(file))); err != nil {
+		return "", err
+	} else {
+		_ = destFile.Close()
+		return filepath.Abs(downloadFile(file, dir, destFile.Name()))
+	}
 }
 
 // createTempDir creates a temp directory in a specific location with a pattern


### PR DESCRIPTION
Fixes #469 

Use the TempFile function to avoid name conflicts in copied files in the temporary directory.

In 3.4.0, with a values file in folderX/values.yaml, helmsman generates a temporary file in .helmsman-tmp/tmp123456789/values.yaml, overwriting any other values.yaml file already copied there.

This PR randomizes the name of the temporary file: .helmsman-tmp/tmp123456789/520934115values.yaml, resolving the conflict.