### PR TITLE
Add the Critical(string) function to Logger

### DIFF
--- a/internal/app/logging.go
+++ b/internal/app/logging.go
@@ -9,6 +9,18 @@ import (
 
 type Logger struct {
 	*logger.Logger
+	LoggerInterface
+}
+
+type LoggerInterface interface {
+	Info(string)
+	Debug(string)
+	Verbose(string)
+	Error(string)
+	Warning(string)
+	Notice(string)
+	Critical(string)
+	Fatal(string)
 }
 
 var log *Logger
@@ -43,6 +55,13 @@ func (l *Logger) Warning(message string) {
 
 func (l *Logger) Notice(message string) {
 	baseLogger.Notice(message)
+}
+
+func (l *Logger) Critical(message string) {
+	if _, err := url.ParseRequestURI(settings.SlackWebhook); err == nil {
+		notifySlack(message, settings.SlackWebhook, true, flags.apply)
+	}
+	baseLogger.Critical(message)
 }
 
 func (l *Logger) Fatal(message string) {


### PR DESCRIPTION
Fixes #473 

With this fix we get the critical message when a variable is not defined instead of the segmentation fault:

```
2020-05-19 09:59:13 INFO: validating environment variables in /Users/ndegory/Git/src/REDACTED/tmp945558632/884846247values.yaml
2020-05-19 09:59:13 CRITICAL: $REGION is used as an env variable but is currently unset. Either set it or escape it like so: $$REGION
```

Added an interface so that this kind of issues can be seen at compilation time.