### PR TITLE
Run helm tests also when upgrading chart

### DIFF
--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -355,6 +355,10 @@ func (r *release) upgrade(p *plan) {
 
 	p.addCommand(cmd, r.Priority, r, before, after)
 
+	if r.Test {
+		r.test(p)
+	}
+
 }
 
 // reInstall uninstalls a release and reinstalls it.


### PR DESCRIPTION
To be honest I don't know why the helm tests were only considered for install action. :-) 