### PR TITLE
fix: handle default app name even when --skip-validation is used

### DIFF
--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -240,6 +240,13 @@ func (c *cli) readState(s *state) {
 		}
 	}
 
+	// Default app.Name to state name when unset
+	for appName, app := range s.Apps {
+		if app.Name == "" {
+			app.Name = appName
+		}
+	}
+
 	if len(c.target) > 0 {
 		s.TargetMap = map[string]bool{}
 		for _, v := range c.target {

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -63,12 +63,8 @@ func (r *release) isConsideredToRun(s *state) bool {
 }
 
 // validate validates if a release inside a desired state meets the specifications or not.
-// check the full specification @ https://github.com/Praqma/helmsman/docs/desired_state_spec.md
+// check the full specification @ https://github.com/Praqma/helmsman/blob/master/docs/desired_state_specification.md
 func (r *release) validate(appLabel string, names map[string]map[string]bool, s *state) error {
-	if r.Name == "" {
-		r.Name = appLabel
-	}
-
 	if names[r.Name][r.Namespace] {
 		return errors.New("release name must be unique within a given namespace")
 	}

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -67,7 +67,7 @@ func (s *state) toFile(file string) {
 }
 
 // validate validates that the values specified in the desired state are valid according to the desired state spec.
-// check https://github.com/Praqma/Helmsman/docs/desired_state_spec.md for the detailed specification
+// check https://github.com/Praqma/helmsman/blob/master/docs/desired_state_specification.md for the detailed specification
 func (s *state) validate() error {
 
 	// apps


### PR DESCRIPTION
A missing app.Name in the DSF would only default to the app state key when the state was validated. The `--skip-validation` flag would fallback to empty names, which unintendedly attempts to delete and install the release:

```
2020-10-09 09:13:23 NOTICE: Release [  ] version [ x.y.z ] will be installed in [ mynamespace ] namespace -- priority: -1000
2020-10-09 09:13:23 WARNING: Untracked release [ myapp ] found and it will be deleted -- priority: -1000
```