### PR TITLE
Add --always-upgrade flag

### DIFF
--- a/docs/cmd_reference.md
+++ b/docs/cmd_reference.md
@@ -8,6 +8,9 @@ This lists available CMD options in Helmsman:
 
 > you can find the CMD options for the version you are using by typing: `helmsman -h` or `helmsman --help`
 
+  `--always-upgrade`
+        upgrade release even if no changes are found.
+
   `--apply`
         apply the plan directly.
 

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -64,6 +64,7 @@ type cli struct {
 	noCleanup             bool
 	migrateContext        bool
 	parallel              int
+	alwaysUpgrade         bool
 }
 
 func printUsage() {
@@ -107,7 +108,8 @@ func (c *cli) parse() {
 	flag.BoolVar(&c.updateDeps, "update-deps", false, "run 'helm dep up' for local chart")
 	flag.BoolVar(&c.forceUpgrades, "force-upgrades", false, "use --force when upgrading helm releases. May cause resources to be recreated.")
 	flag.BoolVar(&c.noCleanup, "no-cleanup", false, "keeps any credentials files that has been downloaded on the host where helmsman runs.")
-	flag.BoolVar(&c.migrateContext, "migrate-context", false, "Updates the context name for all apps defined in the DSF and applies Helmsman labels. Using this flag is required if you want to change context name after it has been set.")
+	flag.BoolVar(&c.migrateContext, "migrate-context", false, "updates the context name for all apps defined in the DSF and applies Helmsman labels. Using this flag is required if you want to change context name after it has been set.")
+	flag.BoolVar(&c.alwaysUpgrade, "always-upgrade", false, "upgrade release even if no changes are found")
 	flag.Usage = printUsage
 	flag.Parse()
 

--- a/internal/app/decision_maker.go
+++ b/internal/app/decision_maker.go
@@ -406,7 +406,10 @@ func (cs *currentState) inspectUpgradeScenario(r *release, p *plan, chartName, c
 				" ]. Delete of the current release will be planned and new chart will be installed in namespace [ "+
 				r.Namespace+" ]", r.Priority, change)
 		} else {
-			if diff := r.diff(); diff != "" {
+			if flags.alwaysUpgrade {
+				r.upgrade(p)
+				p.addDecision("Release [ "+r.Name+" ] will be updated (forced)", r.Priority, change)
+			} else if diff := r.diff(); diff != "" {
 				r.upgrade(p)
 				p.addDecision("Release [ "+r.Name+" ] will be updated", r.Priority, change)
 			} else {


### PR DESCRIPTION
Add flag to run an upgrade even if helm diff finds no changes, allowing to overwrite manual changes made to the cluster (works around the missing 3-way diff in the helm-diff plugin as described in #487 )