### PR TITLE
Add retryExec func for getting cluster status methods

### DIFF
--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -264,7 +264,7 @@ func (c *cli) readState(s *state) {
 	if !c.skipValidation {
 		// validate the desired state content
 		if len(c.files) > 0 {
-			log.Info("Validating desired state definition...")
+			log.Info("Validating desired state definition")
 			if err := s.validate(); err != nil { // syntax validation
 				log.Fatal(err.Error())
 			}

--- a/internal/app/command.go
+++ b/internal/app/command.go
@@ -32,16 +32,15 @@ func (c *command) String() string {
 func (c *command) retryExec(attempts int) exitStatus {
 	var result exitStatus
 
-	for i := 0; ; i++ {
+	for i := 0; i < attempts; i++ {
 		result = c.exec()
 		if result.code == 0 {
 			return result
 		}
-		if i >= (attempts - 1) {
-			break
+		if i < (attempts - 1) {
+			time.Sleep(time.Duration(math.Pow(2, float64(2+i))) * time.Second)
+			log.Info(fmt.Sprintf("Retrying %s due to error: %s", c.Description, result.errors))
 		}
-		time.Sleep(time.Duration(math.Pow(2, float64(2+i))) * time.Second)
-		log.Info(fmt.Sprintf("Retrying %s due to error: %s", c.Description, result.errors))
 	}
 
 	return exitStatus{

--- a/internal/app/decision_maker.go
+++ b/internal/app/decision_maker.go
@@ -21,7 +21,7 @@ func newCurrentState() *currentState {
 
 // buildState builds the currentState map containing information about all releases existing in a k8s cluster
 func buildState(s *state) *currentState {
-	log.Info("Acquiring current Helm state from cluster...")
+	log.Info("Acquiring current Helm state from cluster")
 
 	cs := newCurrentState()
 	rel := getHelmReleases(s)
@@ -298,8 +298,8 @@ func (cs *currentState) getHelmsmanReleases(s *state) map[string]map[string]bool
 				<-sem
 			}()
 
-			cmd := kubectl([]string{"get", storageBackend, "-n", ns, "-l", "MANAGED-BY=HELMSMAN", "-o", outputFmt, "--no-headers"}, "Getting Helmsman-managed releases")
-			result := cmd.exec()
+			cmd := kubectl([]string{"get", storageBackend, "-n", ns, "-l", "MANAGED-BY=HELMSMAN", "-o", outputFmt, "--no-headers"}, "Getting Helmsman-managed releases from namespace [ " + ns + " ]")
+			result := cmd.retryExec(3)
 			if result.code != 0 {
 				log.Fatal(result.errors)
 			}

--- a/internal/app/helm_release.go
+++ b/internal/app/helm_release.go
@@ -50,10 +50,10 @@ func getHelmReleases(s *state) []helmRelease {
 			var releases []helmRelease
 			var targetReleases []helmRelease
 			defer wg.Done()
-			cmd := helmCmd([]string{"list", "--all", "--max", "0", "--output", "json", "-n", ns}, "Listing all existing releases in [ "+ns+" ] namespace...")
-			result := cmd.exec()
+			cmd := helmCmd([]string{"list", "--all", "--max", "0", "--output", "json", "-n", ns}, "Listing all existing releases in [ "+ns+" ] namespace")
+			result := cmd.retryExec(3)
 			if result.code != 0 {
-				log.Fatal("Failed to list all releases: " + result.errors)
+				log.Fatal(result.errors)
 			}
 			if err := json.Unmarshal([]byte(result.output), &releases); err != nil {
 				log.Fatal(fmt.Sprintf("failed to unmarshal Helm CLI output: %s", err))

--- a/internal/app/kube_helpers.go
+++ b/internal/app/kube_helpers.go
@@ -50,7 +50,7 @@ func kubectl(args []string, desc string) command {
 // createNamespace creates a namespace in the k8s cluster
 func createNamespace(ns string) {
 	checkCmd := kubectl([]string{"get", "namespace", ns}, "Looking for namespace [ "+ns+" ]")
-	checkResult := checkCmd.exec()
+	checkResult := checkCmd.retryExec(3)
 	if checkResult.code == 0 {
 		log.Verbose("Namespace [ " + ns + " ] exists")
 		return

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -37,7 +37,7 @@ func Main() {
 	if len(s.GroupMap) > 0 {
 		s.TargetMap = s.getAppsInGroupsAsTargetMap()
 		if len(s.TargetMap) == 0 {
-			log.Info("No apps defined with -group flag were found, exiting...")
+			log.Info("No apps defined with -group flag were found, exiting")
 			os.Exit(0)
 		}
 	}
@@ -45,7 +45,7 @@ func Main() {
 		s.TargetApps = s.getAppsInTargetsOnly()
 		s.TargetNamespaces = s.getNamespacesInTargetsOnly()
 		if len(s.TargetApps) == 0 {
-			log.Info("No apps defined with -target flag were found, exiting...")
+			log.Info("No apps defined with -target flag were found, exiting")
 			os.Exit(0)
 		}
 	}
@@ -53,7 +53,7 @@ func Main() {
 	curContext = s.Context
 
 	// set the kubecontext to be used Or create it if it does not exist
-	log.Info("Setting up kubectl...")
+	log.Info("Setting up kubectl")
 	if !setKubeContext(settings.KubeContext) {
 		if err := createContext(&s); err != nil {
 			log.Fatal(err.Error())
@@ -61,7 +61,7 @@ func Main() {
 	}
 
 	// add repos -- fails if they are not valid
-	log.Info("Setting up helm...")
+	log.Info("Setting up helm")
 	if err := addHelmRepos(s.HelmRepos); err != nil && !flags.destroy {
 		log.Fatal(err.Error())
 	}
@@ -69,7 +69,7 @@ func Main() {
 	if flags.apply || flags.dryRun || flags.destroy {
 		// add/validate namespaces
 		if !flags.noNs {
-			log.Info("Setting up namespaces...")
+			log.Info("Setting up namespaces")
 			if flags.nsOverride == "" {
 				addNamespaces(&s)
 			} else {
@@ -80,7 +80,7 @@ func Main() {
 	}
 
 	if !flags.skipValidation {
-		log.Info("Validating charts...")
+		log.Info("Validating charts")
 		// validate charts-versions exist in defined repos
 		if err := validateReleaseCharts(&s); err != nil {
 			log.Fatal(err.Error())
@@ -98,7 +98,7 @@ func Main() {
 		s.updateContextLabels()
 	}
 
-	log.Info("Preparing plan...")
+	log.Info("Preparing plan")
 	cs := buildState(&s)
 	p := cs.makePlan(&s)
 	if !flags.keepUntrackedReleases {

--- a/internal/app/plan.go
+++ b/internal/app/plan.go
@@ -85,7 +85,7 @@ func (p *plan) addDecision(decision string, priority int, decisionType decisionT
 func (p *plan) exec() {
 	p.sort()
 	if len(p.Commands) > 0 {
-		log.Info("Executing plan... ")
+		log.Info("Executing plan")
 	} else {
 		log.Info("Nothing to execute")
 	}

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -682,3 +682,21 @@ func isValidFile(filePath string, allowedFileTypes []string) error {
 	}
 	return nil
 }
+
+func retry(attempts int, sleep time.Duration, callback func() error) (err error) {
+	for i := 0; ; i++ {
+		err = callback()
+		if err == nil {
+			return
+		}
+
+		if i >= (attempts - 1) {
+			break
+		}
+
+		time.Sleep(sleep)
+
+		log.Info(fmt.Sprintf("Retrying %s", err))
+	}
+	return fmt.Errorf("after %d attempts of %s", attempts, err)
+}

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -682,21 +682,3 @@ func isValidFile(filePath string, allowedFileTypes []string) error {
 	}
 	return nil
 }
-
-func retry(attempts int, sleep time.Duration, callback func() error) (err error) {
-	for i := 0; ; i++ {
-		err = callback()
-		if err == nil {
-			return
-		}
-
-		if i >= (attempts - 1) {
-			break
-		}
-
-		time.Sleep(sleep)
-
-		log.Info(fmt.Sprintf("Retrying %s", err))
-	}
-	return fmt.Errorf("after %d attempts of %s", attempts, err)
-}


### PR DESCRIPTION
I hope this will mitigate the problems from #539

I've added retryExec to run `Getting Helmsman-managed releases` and `Listing all existing releases` with retries. It won't affect anyone not experiencing the same issues, but for those that do (like https://github.com/helm/helm/issues/7997) it should at least do its best. 

In the next iteration we can implement exponential backoff instead of waiting fixed time as it is now, but first I'd like to release this change and collect some examples.