### PR TITLE
Add retryExec to diff()

### DIFF
--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -337,7 +337,7 @@ func (r *release) diff() string {
 
 	cmd := helmCmd(concat([]string{"diff", colorFlag, suppressDiffSecretsFlag}, diffContextFlag, r.getHelmArgsFor("diff")), "Diffing release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ]")
 
-	result := cmd.exec()
+	result := cmd.retryExec(3)
 	if result.code != 0 {
 		log.Fatal(fmt.Sprintf("Command returned with exit code: %d. And error message: %s ", result.code, result.errors))
 	} else {


### PR DESCRIPTION
I forgot to wrap helm diff command with retryExec.
I'd also like to release it as 3.5.1 if possible.