### PR TITLE
-update-deps: run "helm dep up" concurrently

### DIFF
--- a/internal/app/decision_maker.go
+++ b/internal/app/decision_maker.go
@@ -68,7 +68,6 @@ func (cs *currentState) makePlan(s *state) *plan {
 	for _, r := range s.Apps {
 		// To be honest, the helmCmd function should probably pass back a channel at this point, making the resource pool "global", for all helm commands.
 		// It would make more sense than parallelising *some of the workload* like we do here with r.checkChartDepUpdate(), leaving some helm commands outside the concurrent part.
-		r.checkChartDepUpdate()
 		sem <- struct{}{}
 		wg.Add(1)
 		go func(r *release, c *chartInfo) {
@@ -76,6 +75,7 @@ func (cs *currentState) makePlan(s *state) *plan {
 				wg.Done()
 				<-sem
 			}()
+			r.checkChartDepUpdate()
 			cs.decide(r, s.Namespaces[r.Namespace], p, c)
 		}(r, s.ChartInfo[r.Chart][r.Version])
 	}

--- a/internal/app/helm_helpers.go
+++ b/internal/app/helm_helpers.go
@@ -106,7 +106,7 @@ func helmPluginExists(plugin string) bool {
 
 // updateChartDep updates dependencies for a local chart
 func updateChartDep(chartPath string) error {
-	cmd := helmCmd([]string{"dependency", "update", chartPath}, "Updating dependency for local chart [ "+chartPath+" ]")
+	cmd := helmCmd([]string{"dependency", "update", "--skip-refresh", chartPath}, "Updating dependency for local chart [ "+chartPath+" ]")
 
 	result := cmd.Exec()
 	if result.code != 0 {


### PR DESCRIPTION
also add '--skip-refresh' flag as 'helm repo update' is already run by helmsman, and is otherwise not safe to use in parallel