### PR TITLE
fetch "helm plugins list" once

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV HELM_DIFF_VERSION=$GLOBAL_HELM_DIFF_VERSION
 
 RUN apk add --update --no-cache ca-certificates git openssh ruby curl tar gzip make bash
 
-RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl
+RUN curl --retry 5 -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl
 RUN chmod +x /usr/local/bin/kubectl
 
 RUN curl -Lk https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz | tar zxv -C /tmp

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -18,6 +18,7 @@ var (
 	settings   *config
 	curContext string
 	log        = &Logger{}
+	plugins    map[string]bool
 )
 
 func init() {


### PR DESCRIPTION
Stops helmsman from executing `helm plugin list` for every targets. List is cached on first call.
Also add a retry on curl as the CI build seems to fail often there.