### PR TITLE
fix: isValidFile error for hooks should not lead to a file resolve.

### DIFF
--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -485,13 +485,13 @@ func (r *release) getHookCommands(hookType, ns string) []hookCmd {
 	var cmds []hookCmd
 	if _, ok := r.Hooks[hookType]; ok {
 		hook := r.Hooks[hookType].(string)
-		if err := isValidFile(hook, []string{".yaml", ".yml", ".json"}); err != nil {
+		if err := isValidFile(hook, []string{".yaml", ".yml", ".json"}); err == nil {
 			cmd := kubectl([]string{"apply", "-n", ns, "-f", hook, flags.getKubeDryRunFlag("apply")}, "Apply "+hook+" manifest "+hookType)
 			cmds = append(cmds, hookCmd{Command: cmd, Type: hookType})
 			if wait, waitCmds := r.shouldWaitForHook(hook, hookType, ns); wait {
 				cmds = append(cmds, waitCmds...)
 			}
-		} else {
+		} else { // shell hook
 			args := strings.Fields(hook)
 			cmds = append(cmds, hookCmd{
 				Command: Command{

--- a/internal/app/release_files.go
+++ b/internal/app/release_files.go
@@ -19,7 +19,7 @@ func (r *release) substituteVarsInStaticFiles() {
 	for key, val := range r.Hooks {
 		if key != "deleteOnSuccess" && key != "successTimeout" && key != "successCondition" {
 			hook := val.(string)
-			if err := isValidFile(hook, []string{".yaml", ".yml"}); err != nil {
+			if err := isValidFile(hook, []string{".yaml", ".yml"}); err == nil {
 				r.Hooks[key] = substituteVarsInYaml(hook)
 			}
 		}
@@ -45,7 +45,7 @@ func (r *release) resolvePaths(dir, downloadDest string) {
 	for key, val := range r.Hooks {
 		if key != "deleteOnSuccess" && key != "successTimeout" && key != "successCondition" {
 			hook := val.(string)
-			if err := isValidFile(hook, []string{".yaml", ".yml", ".json"}); err != nil {
+			if err := isValidFile(hook, []string{".yaml", ".yml", ".json"}); err == nil {
 				r.Hooks[key], _ = resolveOnePath(hook, dir, downloadDest)
 			}
 		}

--- a/internal/app/state_files.go
+++ b/internal/app/state_files.go
@@ -164,7 +164,7 @@ func (s *state) expand(relativeToFile string) {
 		for key, val := range s.Settings.GlobalHooks {
 			if key != "deleteOnSuccess" && key != "successTimeout" && key != "successCondition" {
 				hook := val.(string)
-				if err := isValidFile(hook, []string{".yaml", ".yml"}); err != nil {
+				if err := isValidFile(hook, []string{".yaml", ".yml"}); err == nil {
 					s.Settings.GlobalHooks[key] = substituteVarsInYaml(hook)
 				}
 			}
@@ -180,7 +180,7 @@ func (s *state) expand(relativeToFile string) {
 	for key, val := range s.Settings.GlobalHooks {
 		if key != "deleteOnSuccess" && key != "successTimeout" && key != "successCondition" {
 			hook := val.(string)
-			if err := isValidFile(hook, []string{".yaml", ".yml", ".json"}); err != nil {
+			if err := isValidFile(hook, []string{".yaml", ".yml", ".json"}); err == nil {
 				s.Settings.GlobalHooks[key], _ = resolveOnePath(hook, dir, downloadDest)
 			}
 		}


### PR DESCRIPTION
A first cut of shell hooks was released in https://github.com/Praqma/helmsman/pull/546 -- looks like there's a bug in how `isValidFile` is being used for hooks. I think it should be a `==` instead of `!=` in a few of these places.

**Repro**

DSF:
```
<snip>
apps:
    sample:
        name: sample
        valuesFiles:
          - sample-values.yaml
        <snip>
        hooks:
            postInstall: my-legit-command-here
```


Error:
```
...
2020-11-23 22:18:07 INFO: sample-values.yaml will be used from local file system.
2020-11-23 22:18:07 INFO: cluster-meta.yaml will be used from local file system.
2020-11-23 22:18:07 CRITICAL: open : no such file or directory
```

This is definitely a hotfix, though. Leaving as WIP while I continue to validate and open to suggestions of more durable solutions here.

cc @luisdavim 