### PR TITLE
feat: Helm test command should run first after the release is installed.

### DIFF
--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -126,7 +126,7 @@ func (r *release) validate(appLabel string, seen map[string]map[string]bool, s *
 // testRelease creates a Helm command to test a particular release.
 func (r *release) test(afterCommands *[]hookCmd) {
 	cmd := helmCmd(r.getHelmArgsFor("test"), "Running tests for release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ]")
-	*afterCommands = append(*afterCommands, hookCmd{Command: cmd, Type: test})
+	*afterCommands = append([]hookCmd{{Command: cmd, Type: test}}, *afterCommands...)
 }
 
 // installRelease creates a Helm command to install a particular release in a particular namespace using a particular Tiller.


### PR DESCRIPTION
Helm tests currently modify their Helm releases, clobbering any labels / annotations. This has previously caused problems with Helmsman's labelling, and will also cause problems if a shell post-hook does anything with those release secrets.

As such, we should run Helm tests first thing, immediately after the release is installed / upgraded.