### PR TITLE
feat: commands should optionally log stdout on failures.

### DIFF
--- a/internal/app/plan.go
+++ b/internal/app/plan.go
@@ -186,6 +186,7 @@ func execOne(cmd Command, targetRelease *release) error {
 	log.Notice(cmd.Description)
 	result := cmd.Exec()
 	if result.code != 0 {
+		log.Verbose(result.output)
 		errorMsg := result.errors
 		if !flags.verbose {
 			errorMsg = strings.Split(result.errors, "---")[0]


### PR DESCRIPTION
Shell hooks potentially have helpful `stdout` contents that we'd want to optionally (verbose only) see in an error scenario.