### PR TITLE
Fix notifySlack segmentation fault

### DIFF
--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -333,6 +333,7 @@ func notifySlack(content string, url string, failure bool, executing bool) bool 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonStr))
 	if err != nil {
 		log.Errorf("Failed to send slack message: %v", err)
+		return false
 	}
 	req.Header.Set("Content-Type", "application/json")
 
@@ -340,6 +341,7 @@ func notifySlack(content string, url string, failure bool, executing bool) bool 
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Errorf("Failed to send notification to slack: %v", err)
+		return false
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
This fixes segmentation fault in notifySlack, when there was an error from http.Client and response was nil.

```
2020-11-30 18:25:07 INFO: Posting notifications to Slack ...
2020/11/30 18:25:08 protocol error: received *http.http2GoAwayFrame before a SETTINGS frame
2020-11-30 18:25:08 INFO: Cleaning up sensitive and temp files
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xcc2939]

goroutine 1 [running]:
github.com/Praqma/helmsman/internal/app.notifySlack(0xc0004bc280, 0x4c, 0xc0000ae1e0, 0x4f, 0xc0004b0000, 0x0)
  	/go/src/github.com/Praqma/helmsman/internal/app/utils.go:548 +0x6f9
github.com/Praqma/helmsman/internal/app.(*plan).sendToSlack(0xc0005080a0)
  	/go/src/github.com/Praqma/helmsman/internal/app/plan.go:224 +0x1bc
github.com/Praqma/helmsman/internal/app.Main()
  	/go/src/github.com/Praqma/helmsman/internal/app/main.go:113 +0x338
main.main()
  	/go/src/github.com/Praqma/helmsman/cmd/helmsman/main.go:8 +0x20