### PR TITLE
Clarify diff error message

### DIFF
--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -178,7 +178,7 @@ func (r *release) diff() (string, error) {
 
 	result := cmd.RetryExec(3)
 	if result.code != 0 {
-		return "", fmt.Errorf("Command returned with exit code: %d. And error message: %s ", result.code, result.errors)
+		return "", fmt.Errorf("Diff for release [%s] in namespace [%s] returned with exit code: %d. And error message: %s ", r.Name, r.Namespace, result.code, result.errors)
 	}
 
 	return result.output, nil


### PR DESCRIPTION
Since helm diff is run parallelly for multiple releases, sometimes it's impossible to distinguish which release the critical error is referring to, e.g.
```
2020-12-01 13:45:32 INFO: Diffing release [ a ] in namespace [ n ]
2020-12-01 13:45:32 INFO: Diffing release [ b ] in namespace [ n ]
2020-12-01 13:45:32 INFO: Diffing release [ c ] in namespace [ n ]
2020-12-01 13:45:32 INFO: Diffing release [ d ] in namespace [ n ]
2020-12-01 13:45:34 CRITICAL: Command returned with exit code: 1. And error message: Error:
Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: 
error validating "": error validating data: ValidationError(Deployment.spec): unknown field "updateStrategy" 
in io.k8s.api.apps.v1.DeploymentSpec

Error: plugin "diff" exited with error
```
That's why I added a more descriptive error message containing release name and namespace.