### PR TITLE
Revert Clarify diff error message

### DIFF
--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -178,7 +178,7 @@ func (r *release) diff() (string, error) {
 
 	result := cmd.RetryExec(3)
 	if result.code != 0 {
-		return "", fmt.Errorf("Diff for release [%s] in namespace [%s] returned with exit code: %d. And error message: %s ", r.Name, r.Namespace, result.code, result.errors)
+		return "", fmt.Errorf("Command returned with exit code: %d. And error message: %s ", result.code, result.errors)
 	}
 
 	return result.output, nil


### PR DESCRIPTION
This reverts the change from #560, turns out I tested it on older version of helmsman when cmd.Exec was used instead of cmd.RetryExec for `helm diff`. Now it looks like this clarification was redundant:

```
2020-12-10 11:21:28 ERROR: Diff for release [x] in namespace [y] returned with exit code: 1.
And error message: After 3 attempts of Diffing release [ x ] in namespace [ y ], it failed with:
Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from
release manifest: error validating "": error validating data: ValidationError(Deployment.spec):
unknown field "updateStrategy" in io.k8s.api.apps.v1.DeploymentSpec
```
@mkubaczyk Sorry for this confusion