### PR TITLE
fix: side-effect on r.SecretsFiles when having multiple successive call

### DIFF
--- a/internal/app/release_files.go
+++ b/internal/app/release_files.go
@@ -80,14 +80,17 @@ func (r *release) getValuesFiles() []string {
 		fileList = append(fileList, r.SecretsFile+".dec")
 	} else if len(r.SecretsFiles) > 0 {
 		for i := 0; i < len(r.SecretsFiles); i++ {
+			if isOfType(r.SecretsFiles[i], []string{".dec"}) {
+				// if .dec extension is added before to the secret filename, don't add it again.
+				// This happens at upgrade time (where diff and upgrade both call this function)
+				// and we don't need to decrypt the file again
+				continue
+			}
+
 			if err := decryptSecret(r.SecretsFiles[i]); err != nil {
 				log.Fatal(err.Error())
 			}
-			// if .dec extension is added before to the secret filename, don't add it again.
-			// This happens at upgrade time (where diff and upgrade both call this function)
-			if !isOfType(r.SecretsFiles[i], []string{".dec"}) {
-				r.SecretsFiles[i] = r.SecretsFiles[i] + ".dec"
-			}
+			r.SecretsFiles[i] = r.SecretsFiles[i] + ".dec"
 		}
 		fileList = append(fileList, r.SecretsFiles...)
 	}


### PR DESCRIPTION
Hey folks 👋 

I'm using [helm-secrets](https://github.com/jkroepke/helm-secrets) with the [vault driver](https://github.com/jkroepke/helm-secrets#change-secret-driver) and I'm facing that issue:
```
HELM_SECRETS_DRIVER=vault helmsman -f state_v3.toml -target foo -show-diff -debug

 _          _ 
| |        | | 
| |__   ___| |_ __ ___  ___ _ __ ___   __ _ _ __
| '_ \ / _ \ | '_ ` _ \/ __| '_ ` _ \ / _` | '_ \ 
| | | |  __/ | | | | | \__ \ | | | | | (_| | | | | 
|_| |_|\___|_|_| |_| |_|___/_| |_| |_|\__,_|_| |_| version: v3.6.3
A Helm-Charts-as-Code tool.

2021-01-19 23:35:05 DEBUG: helm version --short -c
2021-01-19 23:35:05 DEBUG: helm version --short -c
2021-01-19 23:35:05 DEBUG: kubectl version --client --short
2021-01-19 23:35:05 DEBUG: helm plugin list
2021-01-19 23:35:05 INFO: Parsed TOML [[ state_v3.toml ]] successfully and found [ X ] apps
2021-01-19 23:35:05 INFO: Validating desired state definition

.........


Applications: 
--------------- 

	name:  foo
	description:  
	namespace:  foo
	enabled:  true
	chart:  foo
	version:  0.3.0
	valuesFile:  
	valuesFiles:  .helmsman-tmp/tmp326815726/177983580foo.values.yaml
	postRenderer:  
	test:  false
	protected:  false
	wait:  true
	priority:  0
	SuccessCondition:  <nil>
	SuccessTimeout:  <nil>
	DeleteOnSuccess:  <nil>
	preInstall:  <nil>
	postInstall:  <nil>
	preUpgrade:  <nil>
	postUpgrade:  <nil>
	preDelete:  <nil>
	postDelete:  <nil>
	no-hooks:  false
	timeout:  0
	values to override from env:

Targets: 
--------------- 
foo
2021-01-19 23:35:05 INFO: Setting up kubectl
2021-01-19 23:35:05 DEBUG: kubectl config use-context dev.jt
2021-01-19 23:35:05 INFO: Setting up helm
2021-01-19 23:35:05 DEBUG: helm repo list --output json
2021-01-19 23:35:06 DEBUG: helm version --short -c
2021-01-19 23:35:06 DEBUG: helm repo update
2021-01-19 23:35:39 INFO: Getting chart information
2021-01-19 23:35:39 DEBUG: helm show chart foo --version 0.3.0
2021-01-19 23:35:41 INFO: Charts validated.
2021-01-19 23:35:41 INFO: Preparing plan
2021-01-19 23:35:41 INFO: Acquiring current Helm state from cluster
2021-01-19 23:35:41 DEBUG: helm list --all --max 0 --output json -n foo
2021-01-19 23:35:45 DEBUG: kubectl get secret -n foo -l owner=helm -l name=foo -o jsonpath='{.items[-1].metadata.labels.HELMSMAN_CONTEXT}'
2021-01-19 23:35:47 DEBUG: helm plugin list
2021-01-19 23:35:47 DEBUG: helm secrets dec .helmsman-tmp/tmp200982133/921295371foo.secrets.yaml
2021-01-19 23:35:49 DEBUG: helm diff  --suppress-secrets upgrade foo foo --version 0.3.0 --namespace foo -f .helmsman-tmp/tmp326815726/177983580foo.values.yaml -f .helmsman-tmp/tmp200982133/921295371foo.secrets.yaml.dec
  ...
2021-01-19 23:35:57 DEBUG: helm plugin list
2021-01-19 23:35:57 DEBUG: helm secrets dec .helmsman-tmp/tmp200982133/921295371foo.secrets.yaml.dec <---------
2021-01-19 23:35:57 CRITICAL: Error: plugin "secrets" exited with error
```
By doing a bit of investigation I came to that conclusion:

In the case there is several successive action called in the same run (diff, upgrade, ...) the field r.SecretsFiles is overwritten during the first call. Therefore the field r.SecretsFiles is different between the first call and the following ones.

One side effect of that can be seen by doing helmsman -show-diff with the secretFiles enabled (helm-secrets plugin + vault driver): helmsman will try do decrypt a file already decrypted because the list of secretFiles changed.

Don't hesitate to ask more details if needed

Cheers 😉 