### PR TITLE
tests are not run with a normal `go test ./...`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 ifneq ($(OS),Windows_NT)
   # Before we start test that we have the mandatory executables available
-  EXECUTABLES = go
+  EXECUTABLES = go helm
   OK := $(foreach exec,$(EXECUTABLES),\
     $(if $(shell which $(exec)),some string,$(error "No $(exec) in PATH, please install $(exec)")))
 endif
@@ -73,7 +73,7 @@ repo:
 .PHONY: repo
 
 test: deps vet repo ## Run unit tests
-	@go test -v -cover -p=1 ./... -args -f ../../examples/example.toml
+	@go test -v -cover -p=1 ./...
 .PHONY: test
 
 cross: deps ## Create binaries for all OSs

--- a/internal/app/cli_test.go
+++ b/internal/app/cli_test.go
@@ -1,6 +1,9 @@
 package app
 
-import "testing"
+import (
+	"github.com/apsdehal/go-logger"
+	"testing"
+)
 
 var _ = func() bool {
 	testing.Init()
@@ -8,6 +11,8 @@ var _ = func() bool {
 }()
 
 func Test_readState(t *testing.T) {
+	l, _ := logger.New()
+	log = &Logger{Logger: l}
 	type result struct {
 		numApps        int
 		numNSs         int

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -21,13 +21,11 @@ var (
 	log        = &Logger{}
 )
 
-func init() {
-	// Parse cli flags and read config files
-	flags.parse()
-}
-
 // Main is the app main function
 func Main() {
+	// Parse cli flags and read config files
+	flags.parse()
+
 	var s state
 
 	// delete temp files with substituted env vars when the program terminates


### PR DESCRIPTION
When just running `go test ./...`, tests are never being run in `internal/app` (the only place there are tests) because of the package's `init()` function. It "parses flags", e.g. tries a full run and quits because there's no Helmsman file provided.

This is apparently why the `make test` command passes in a dummy Helmsman file via `-args` to the test binary. With that Helmsman file provided, we make it past the `init()` into real tests.

This is not ideal for lots of reasons:
- It impedes local development and testing unless people know about a specific hack that's embedded into the Makefile. Someone (like me) will simply run `go test ./...` and maybe be confused why the banner shows, but otherwise see everything "passing" all ok. Trying to run single tests, all tests -- it's all confusing and reports okay, because nothing runs.
- People can't get these tests passing with `make test` locally because they need a very specific dependency setup. Only getting these tests to pass on CircleCI by building dependencies into the Dockerfile is not great - we can't expect people to have `helm` and `helm diff` and `eyaml` all installed just to test some potentially dead-simple, dependency-free Go code.
- There's no good reason I can see to keep the `init` code like this.

To be clear - everything is still fine on CircleCI because the Dockerfile calls Make commands and also build a test environment with certain binaries and plugins.

To reproduce, just run `go test ./... -list .` on the `master` branch, then try on this branch. Same thing with just running tests, try `go test ./... -v` on `master` versus this.

This is a WIP because I don't think the state I've left this is ideal, but maybe it's a good enough start. Ideally, end state of this PR is: someone should be able to run `go test ./...` or `make test` locally - WITHOUT having the file hack or every dependency manually installed - and everything will pass like it would on CircleCI.