### PR TITLE
feat: command.Exec() returns (*ExitStatus, error) enabling more idiomatic error management.

### DIFF
--- a/internal/app/command_test.go
+++ b/internal/app/command_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -43,51 +42,57 @@ func Test_toolExists(t *testing.T) {
 	}
 }
 
-func Test_command_exec(t *testing.T) {
-	type fields struct {
-		Cmd         string
-		Args        []string
-		Description string
+func TestCommandExec(t *testing.T) {
+	type input struct {
+		cmd  string
+		args []string
+		desc string
+	}
+	type expected struct {
+		err    error
+		output string
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		want   int
-		want1  string
+		name     string
+		input    input
+		expected expected
 	}{
 		{
 			name: "echo",
-			fields: fields{
-				Cmd:         "bash",
-				Args:        []string{"-c", "echo this is fun"},
-				Description: "A bash command execution test with echo.",
+			input: input{
+				cmd:  "bash",
+				args: []string{"-c", "echo this is fun"},
+				desc: "A bash command execution test with echo.",
 			},
-			want:  0,
-			want1: "this is fun",
+			expected: expected{
+				output: "this is fun",
+			},
 		}, {
 			name: "exitCode",
-			fields: fields{
-				Cmd:         "bash",
-				Args:        []string{"-c", "echo $?"},
-				Description: "A bash command execution test with exitCode.",
+			input: input{
+				cmd:  "bash",
+				args: []string{"-c", "echo $?"},
+				desc: "A bash command execution test with exitCode.",
 			},
-			want:  0,
-			want1: "0",
+			expected: expected{
+				output: "0",
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := Command{
-				Cmd:         tt.fields.Cmd,
-				Args:        tt.fields.Args,
-				Description: tt.fields.Description,
+				Cmd:         tt.input.cmd,
+				Args:        tt.input.args,
+				Description: tt.input.desc,
 			}
-			got := c.Exec()
-			if got.code != tt.want {
-				t.Errorf("command.exec() got = %v, want %v", got.code, tt.want)
+			res, err := c.Exec()
+			if err != nil && tt.expected.err.Error() != err.Error() {
+				t.Errorf("unexpected error running command.exec(): %v", err)
 			}
-			if strings.TrimSpace(got.output) != tt.want1 {
-				t.Errorf("command.exec() got1 = %v, want %v", got.output, tt.want1)
+
+			if res.output != tt.expected.output {
+				t.Errorf("command.exec() expected: %v, got %v", tt.expected.output, res.output)
 			}
 		})
 	}

--- a/internal/app/command_test.go
+++ b/internal/app/command_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func Test_toolExists(t *testing.T) {
+func TestToolExists(t *testing.T) {
 	type args struct {
 		tool string
 	}
@@ -49,13 +49,14 @@ func TestCommandExec(t *testing.T) {
 		desc string
 	}
 	type expected struct {
+		code   int
 		err    error
 		output string
 	}
 	tests := []struct {
-		name     string
-		input    input
-		expected expected
+		name  string
+		input input
+		want  expected
 	}{
 		{
 			name: "echo",
@@ -64,8 +65,10 @@ func TestCommandExec(t *testing.T) {
 				args: []string{"-c", "echo this is fun"},
 				desc: "A bash command execution test with echo.",
 			},
-			expected: expected{
+			want: expected{
+				code:   0,
 				output: "this is fun",
+				err:    nil,
 			},
 		}, {
 			name: "exitCode",
@@ -74,8 +77,10 @@ func TestCommandExec(t *testing.T) {
 				args: []string{"-c", "echo $?"},
 				desc: "A bash command execution test with exitCode.",
 			},
-			expected: expected{
+			want: expected{
+				code:   0,
 				output: "0",
+				err:    nil,
 			},
 		},
 	}
@@ -86,13 +91,15 @@ func TestCommandExec(t *testing.T) {
 				Args:        tt.input.args,
 				Description: tt.input.desc,
 			}
-			res, err := c.Exec()
-			if err != nil && tt.expected.err.Error() != err.Error() {
-				t.Errorf("unexpected error running command.exec(): %v", err)
+			got, err := c.Exec()
+			if err != tt.want.err {
+				t.Errorf("command.exec() unexpected error got = %v, want %v", err, tt.want.err)
 			}
-
-			if res.output != tt.expected.output {
-				t.Errorf("command.exec() expected: %v, got %v", tt.expected.output, res.output)
+			if got.code != tt.want.code {
+				t.Errorf("command.exec() unexpected code got = %v, want %v", got.code, tt.want.code)
+			}
+			if got.output != tt.want.output {
+				t.Errorf("command.exec() unexpected output got = %v, want %v", got.output, tt.want.output)
 			}
 		})
 	}

--- a/internal/app/decision_maker.go
+++ b/internal/app/decision_maker.go
@@ -209,13 +209,13 @@ func (cs *currentState) getHelmsmanReleases(s *state) map[string]map[string]bool
 			}()
 
 			cmd := kubectl([]string{"get", storageBackend, "-n", ns, "-l", "MANAGED-BY=HELMSMAN", "-o", outputFmt, "--no-headers"}, "Getting Helmsman-managed releases from namespace [ "+ns+" ]")
-			result, err := cmd.RetryExec(3)
+			res, err := cmd.RetryExec(3)
 			if err != nil {
-				log.Fatalf("%v", err)
+				log.Fatal(err.Error())
 			}
 
-			if !strings.EqualFold("No resources found.", strings.TrimSpace(result.output)) {
-				lines = strings.Split(result.output, "\n")
+			if !strings.EqualFold("No resources found.", strings.TrimSpace(res.output)) {
+				lines = strings.Split(res.output, "\n")
 			}
 
 			for _, line := range lines {

--- a/internal/app/decision_maker.go
+++ b/internal/app/decision_maker.go
@@ -209,9 +209,9 @@ func (cs *currentState) getHelmsmanReleases(s *state) map[string]map[string]bool
 			}()
 
 			cmd := kubectl([]string{"get", storageBackend, "-n", ns, "-l", "MANAGED-BY=HELMSMAN", "-o", outputFmt, "--no-headers"}, "Getting Helmsman-managed releases from namespace [ "+ns+" ]")
-			result := cmd.RetryExec(3)
-			if result.code != 0 {
-				log.Fatal(result.errors)
+			result, err := cmd.RetryExec(3)
+			if err != nil {
+				log.Fatalf("%v", err)
 			}
 
 			if !strings.EqualFold("No resources found.", strings.TrimSpace(result.output)) {

--- a/internal/app/helm_helpers.go
+++ b/internal/app/helm_helpers.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -41,12 +40,10 @@ func getChartInfo(chartName, chartVersion string) (*chartInfo, error) {
 
 	cmd := helmCmd([]string{"show", "chart", chartName, "--version", chartVersion}, "Getting latest non-local chart's version "+chartName+"-"+chartVersion+"")
 
-	result := cmd.Exec()
-	if result.code != 0 {
+	result, err := cmd.Exec()
+	if err != nil {
 		maybeRepo := filepath.Base(filepath.Dir(chartName))
-		message := strings.TrimSpace(result.errors)
-
-		return nil, fmt.Errorf("chart [ %s ] version [ %s ] can't be found. Inspection returned error: \"%s\" -- If this is not a local chart, add the repo [ %s ] in your helmRepos stanza", chartName, chartVersion, message, maybeRepo)
+		return nil, fmt.Errorf("chart [ %s ] version [ %s ] can't be found. If this is not a local chart, add the repo [ %s ] in your helmRepos stanza. Error output: %w", chartName, chartVersion, maybeRepo, err)
 	}
 
 	c := &chartInfo{}
@@ -74,9 +71,9 @@ func getChartInfo(chartName, chartVersion string) (*chartInfo, error) {
 func getHelmVersion() string {
 	cmd := helmCmd([]string{"version", "--short", "-c"}, "Checking Helm version")
 
-	result := cmd.Exec()
-	if result.code != 0 {
-		log.Fatal("While checking helm version: " + result.errors)
+	result, err := cmd.Exec()
+	if err != nil {
+		log.Fatalf("Error checking helm version: %v", err)
 	}
 
 	return result.output
@@ -105,9 +102,8 @@ func checkHelmVersion(constraint string) bool {
 func helmPluginExists(plugin string) bool {
 	cmd := helmCmd([]string{"plugin", "list"}, "Validating that [ "+plugin+" ] is installed")
 
-	result := cmd.Exec()
-
-	if result.code != 0 {
+	result, err := cmd.Exec()
+	if err != nil {
 		return false
 	}
 
@@ -118,9 +114,8 @@ func helmPluginExists(plugin string) bool {
 func updateChartDep(chartPath string) error {
 	cmd := helmCmd([]string{"dependency", "update", "--skip-refresh", chartPath}, "Updating dependency for local chart [ "+chartPath+" ]")
 
-	result := cmd.Exec()
-	if result.code != 0 {
-		return errors.New(result.errors)
+	if _, err := cmd.Exec(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -133,18 +128,18 @@ func addHelmRepos(repos map[string]string) error {
 
 	// get existing helm repositories
 	cmdList := helmCmd(concat([]string{"repo", "list", "--output", "json"}), "Listing helm repositories")
-	if reposResult := cmdList.Exec(); reposResult.code == 0 {
-		if err := json.Unmarshal([]byte(reposResult.output), &helmRepos); err != nil {
+	res, err := cmdList.Exec()
+	if err != nil {
+		if err := json.Unmarshal([]byte(res.output), &helmRepos); err != nil {
 			log.Fatal(fmt.Sprintf("failed to unmarshal Helm CLI output: %s", err))
 		}
 		// create map of existing repositories
 		for _, repo := range helmRepos {
 			existingRepos[repo.Name] = repo.URL
 		}
-	} else {
-		if !strings.Contains(reposResult.errors, "no repositories to show") {
-			return fmt.Errorf("while listing helm repositories: %s", reposResult.errors)
-		}
+	}
+	if !strings.Contains(res.output, "no repositories to show") {
+		return fmt.Errorf("error listing helm repositories: %w", err)
 	}
 
 	repoAddFlags := ""
@@ -187,16 +182,16 @@ func addHelmRepos(repos map[string]string) error {
 			}
 		}
 		cmd := helmCmd(concat([]string{"repo", "add", repoAddFlags, repoName, repoURL}, basicAuthArgs), "Adding helm repository [ "+repoName+" ]")
-		if result := cmd.Exec(); result.code != 0 {
-			return fmt.Errorf("While adding helm repository ["+repoName+"]: %s", result.errors)
+		if _, err := cmd.Exec(); err != nil {
+			return fmt.Errorf("error adding helm repository ["+repoName+"]: %w", err)
 		}
 	}
 
 	if !flags.noUpdate && len(repos) > 0 {
 		cmd := helmCmd([]string{"repo", "update"}, "Updating helm repositories")
 
-		if result := cmd.Exec(); result.code != 0 {
-			return errors.New("While updating helm repos : " + result.errors)
+		if _, err := cmd.Exec(); err != nil {
+			return fmt.Errorf("err updating helm repos: %w", err)
 		}
 	}
 

--- a/internal/app/helm_release.go
+++ b/internal/app/helm_release.go
@@ -48,9 +48,9 @@ func getHelmReleases(s *state) []helmRelease {
 			var targetReleases []helmRelease
 			defer wg.Done()
 			cmd := helmCmd([]string{"list", "--all", "--max", "0", "--output", "json", "-n", ns}, "Listing all existing releases in [ "+ns+" ] namespace")
-			result := cmd.RetryExec(3)
-			if result.code != 0 {
-				log.Fatal(result.errors)
+			result, err := cmd.RetryExec(3)
+			if err != nil {
+				log.Fatalf("%v", err)
 			}
 			if err := json.Unmarshal([]byte(result.output), &releases); err != nil {
 				log.Fatal(fmt.Sprintf("failed to unmarshal Helm CLI output: %s", err))

--- a/internal/app/helm_release.go
+++ b/internal/app/helm_release.go
@@ -48,11 +48,11 @@ func getHelmReleases(s *state) []helmRelease {
 			var targetReleases []helmRelease
 			defer wg.Done()
 			cmd := helmCmd([]string{"list", "--all", "--max", "0", "--output", "json", "-n", ns}, "Listing all existing releases in [ "+ns+" ] namespace")
-			result, err := cmd.RetryExec(3)
+			res, err := cmd.RetryExec(3)
 			if err != nil {
-				log.Fatalf("%v", err)
+				log.Fatal(err.Error())
 			}
-			if err := json.Unmarshal([]byte(result.output), &releases); err != nil {
+			if err := json.Unmarshal([]byte(res.output), &releases); err != nil {
 				log.Fatal(fmt.Sprintf("failed to unmarshal Helm CLI output: %s", err))
 			}
 			if len(s.TargetMap) > 0 {

--- a/internal/app/kube_helpers.go
+++ b/internal/app/kube_helpers.go
@@ -47,7 +47,7 @@ func kubectl(args []string, desc string) Command {
 // createNamespace creates a namespace in the k8s cluster
 func createNamespace(ns string) {
 	checkCmd := kubectl([]string{"get", "namespace", ns}, "Looking for namespace [ "+ns+" ]")
-	if _, err := checkCmd.RetryExec(3); err != nil {
+	if _, err := checkCmd.RetryExec(3); err == nil {
 		log.Verbose("Namespace [ " + ns + " ] exists")
 		return
 	}
@@ -113,7 +113,7 @@ spec:
 		log.Fatal(err.Error())
 	}
 
-	definition = definition + Indent(string(d), strings.Repeat(" ", 4))
+	definition += Indent(string(d), strings.Repeat(" ", 4))
 
 	if err := apply(definition, ns, "LimitRange"); err != nil {
 		log.Fatal(err.Error())
@@ -136,7 +136,7 @@ spec:
 `
 
 	for _, customQuota := range quotas.CustomQuotas {
-		definition = definition + Indent(customQuota.Name+": '"+customQuota.Value+"'\n", strings.Repeat(" ", 4))
+		definition += Indent(customQuota.Name+": '"+customQuota.Value+"'\n", strings.Repeat(" ", 4))
 	}
 
 	// Special formatting for custom quotas so manually write these and then set to nil for marshalling
@@ -147,7 +147,7 @@ spec:
 		log.Fatal(err.Error())
 	}
 
-	definition = definition + Indent(string(d), strings.Repeat(" ", 4))
+	definition += Indent(string(d), strings.Repeat(" ", 4))
 
 	if err := apply(definition, ns, "ResourceQuota"); err != nil {
 		log.Fatal(err.Error())
@@ -303,7 +303,7 @@ func getReleaseContext(releaseName, namespace, storageBackend string) string {
 
 	res, err := cmd.Exec()
 	if err != nil {
-		log.Fatalf("%v", err)
+		log.Fatal(err.Error())
 	}
 	rctx := strings.Trim(res.output, `"' `)
 	if rctx == "" {

--- a/internal/app/kube_helpers.go
+++ b/internal/app/kube_helpers.go
@@ -47,19 +47,16 @@ func kubectl(args []string, desc string) Command {
 // createNamespace creates a namespace in the k8s cluster
 func createNamespace(ns string) {
 	checkCmd := kubectl([]string{"get", "namespace", ns}, "Looking for namespace [ "+ns+" ]")
-	checkResult := checkCmd.RetryExec(3)
-	if checkResult.code == 0 {
+	if _, err := checkCmd.RetryExec(3); err != nil {
 		log.Verbose("Namespace [ " + ns + " ] exists")
 		return
 	}
 
 	cmd := kubectl([]string{"create", "namespace", ns}, "Creating namespace [ "+ns+" ]")
-	result := cmd.Exec()
-	if result.code == 0 {
-		log.Info("Namespace [ " + ns + " ] created")
-	} else {
-		log.Fatal("Failed creating namespace [ " + ns + " ] with error: " + result.errors)
+	if _, err := cmd.Exec(); err != nil {
+		log.Fatalf("Failed creating namespace [ "+ns+" ] with error: %v", err)
 	}
+	log.Info("Namespace [ " + ns + " ] created")
 }
 
 // labelNamespace labels a namespace with provided labels
@@ -74,9 +71,8 @@ func labelNamespace(ns string, labels map[string]string) {
 	}
 	cmd := kubectl(args, "Labeling namespace [ "+ns+" ]")
 
-	result := cmd.Exec()
-	if result.code != 0 && flags.verbose {
-		log.Warning(fmt.Sprintf("Could not label namespace [ %s with %v ]. Error message: %s", ns, strings.Join(args[4:], ","), result.errors))
+	if _, err := cmd.Exec(); err != nil && flags.verbose {
+		log.Warning(fmt.Sprintf("Could not label namespace [ %s with %v ]. Error message: %v", ns, strings.Join(args[4:], ","), err))
 	}
 }
 
@@ -92,9 +88,8 @@ func annotateNamespace(ns string, annotations map[string]string) {
 	}
 	cmd := kubectl(args, "Annotating namespace [ "+ns+" ]")
 
-	result := cmd.Exec()
-	if result.code != 0 && flags.verbose {
-		log.Info(fmt.Sprintf("Could not annotate namespace [ %s with %v ]. Error message: %s", ns, strings.Join(args[4:], ","), result.errors))
+	if _, err := cmd.Exec(); err != nil && flags.verbose {
+		log.Info(fmt.Sprintf("Could not annotate namespace [ %s with %v ]. Error message: %v", ns, strings.Join(args[4:], ","), err))
 	}
 }
 
@@ -172,10 +167,9 @@ func apply(definition, ns, kind string) error {
 
 	cmd := kubectl([]string{"apply", "-f", targetFile.Name(), "-n", ns, flags.getKubeDryRunFlag("apply")},
 		"Creating "+kind+" in namespace [ "+ns+" ]")
-	result := cmd.Exec()
 
-	if result.code != 0 {
-		return fmt.Errorf("ERROR: failed to create %s in namespace [ %s ]: %s", kind, ns, result.errors)
+	if _, err := cmd.Exec(); err != nil {
+		return fmt.Errorf("error creating %s in namespace [ %s ]: %w", kind, ns, err)
 	}
 
 	return nil
@@ -247,20 +241,20 @@ func createContext(s *state) error {
 	}
 	cmd := kubectl(setCredentialsCmdArgs, "Creating kubectl context - setting credentials")
 
-	if result := cmd.Exec(); result.code != 0 {
-		return errors.New("failed to create context [ " + s.Settings.KubeContext + " ]:  " + result.errors)
+	if _, err := cmd.Exec(); err != nil {
+		return fmt.Errorf("failed to create context [ "+s.Settings.KubeContext+" ]: %w", err)
 	}
 
 	cmd = kubectl([]string{"config", "set-cluster", s.Settings.KubeContext, "--server=" + s.Settings.ClusterURI, "--certificate-authority=" + caCrt}, "Creating kubectl context - setting cluster")
 
-	if result := cmd.Exec(); result.code != 0 {
-		return errors.New("failed to create context [ " + s.Settings.KubeContext + " ]: " + result.errors)
+	if _, err := cmd.Exec(); err != nil {
+		return fmt.Errorf("failed to create context [ "+s.Settings.KubeContext+" ]: %w", err)
 	}
 
 	cmd = kubectl([]string{"config", "set-context", s.Settings.KubeContext, "--cluster=" + s.Settings.KubeContext, "--user=" + s.Settings.Username}, "Creating kubectl context - setting context")
 
-	if result := cmd.Exec(); result.code != 0 {
-		return errors.New("failed to create context [ " + s.Settings.KubeContext + " ]: " + result.errors)
+	if _, err := cmd.Exec(); err != nil {
+		return fmt.Errorf("failed to create context [ "+s.Settings.KubeContext+" ]: %w", err)
 	}
 
 	if setKubeContext(s.Settings.KubeContext) {
@@ -279,9 +273,7 @@ func setKubeContext(kctx string) bool {
 
 	cmd := kubectl([]string{"config", "use-context", kctx}, "Setting kube context to [ "+kctx+" ]")
 
-	result := cmd.Exec()
-
-	if result.code != 0 {
+	if _, err := cmd.Exec(); err != nil {
 		log.Info("Kubectl context [ " + kctx + " ] does not exist. Attempting to create it...")
 		return false
 	}
@@ -294,9 +286,7 @@ func setKubeContext(kctx string) bool {
 func getKubeContext() bool {
 	cmd := kubectl([]string{"config", "current-context"}, "Getting kubectl context")
 
-	result := cmd.Exec()
-
-	if result.code != 0 || result.output == "" {
+	if res, err := cmd.Exec(); err != nil || res.output == "" {
 		log.Info("Kubectl context is not set")
 		return false
 	}
@@ -311,11 +301,11 @@ func getReleaseContext(releaseName, namespace, storageBackend string) string {
 	// kubectl get secret -l owner=helm,name=argo -n test1 -o=jsonpath='{.items[-1].metadata.labels.HELMSMAN_CONTEXT}'
 	cmd := kubectl([]string{"get", storageBackend, "-n", namespace, "-l", "owner=helm", "-l", "name=" + releaseName, "-o", "jsonpath='{.items[-1].metadata.labels.HELMSMAN_CONTEXT}'"}, "Getting Helmsman context for [ "+releaseName+" ] release")
 
-	result := cmd.Exec()
-	if result.code != 0 {
-		log.Fatal(result.errors)
+	res, err := cmd.Exec()
+	if err != nil {
+		log.Fatalf("%v", err)
 	}
-	rctx := strings.Trim(result.output, `"' `)
+	rctx := strings.Trim(res.output, `"' `)
 	if rctx == "" {
 		rctx = defaultContextName
 	}
@@ -326,11 +316,11 @@ func getReleaseContext(releaseName, namespace, storageBackend string) string {
 func getKubectlClientVersion() string {
 	cmd := kubectl([]string{"version", "--client", "--short"}, "Checking kubectl version")
 
-	result := cmd.Exec()
-	if result.code != 0 {
-		log.Fatal("While checking kubectl version: " + result.errors)
+	res, err := cmd.Exec()
+	if err != nil {
+		log.Fatalf("While checking kubectl version: %v", err)
 	}
-	return result.output
+	return res.output
 }
 
 // getKubeDryRunFlag returns kubectl dry-run flag if helmsman --dry-run flag is enabled

--- a/internal/app/plan.go
+++ b/internal/app/plan.go
@@ -170,10 +170,8 @@ func releaseWithHooks(cmd orderedCommand, storageBackend string, wg *sync.WaitGr
 					annotations = append(annotations, key+"=failed")
 				}
 				log.Verbose(err.Error())
-			} else {
-				if key, err := c.getAnnotationKey(); err == nil {
-					annotations = append(annotations, key+"=ok")
-				}
+			} else if key, err := c.getAnnotationKey(); err == nil {
+				annotations = append(annotations, key+"=ok")
 			}
 		}
 	}

--- a/internal/app/plan.go
+++ b/internal/app/plan.go
@@ -182,33 +182,23 @@ func releaseWithHooks(cmd orderedCommand, storageBackend string, wg *sync.WaitGr
 // execOne executes a single ordered command
 func execOne(cmd Command, targetRelease *release) error {
 	log.Notice(cmd.Description)
-	result := cmd.Exec()
-	if result.code != 0 {
-		log.Verbose(result.output)
-		errorMsg := result.errors
-		if !flags.verbose {
-			errorMsg = strings.Split(result.errors, "---")[0]
-		}
+	res, err := cmd.Exec()
+	if err != nil {
 		if targetRelease != nil {
-			return fmt.Errorf("command for release [%s] returned [ %d ] exit code and error message [ %s ]",
-				targetRelease.Name, result.code, strings.TrimSpace(errorMsg))
-		} else {
-			return fmt.Errorf("%s returned [ %d ] exit code and error message [ %s ]",
-				cmd.Description, result.code, strings.TrimSpace(errorMsg))
+			return fmt.Errorf("command for release [%s] failed: %w", targetRelease.Name, err)
 		}
-
-	} else {
-		log.Notice(result.output)
-		successMsg := "Finished: " + cmd.Description
-		log.Notice(successMsg)
-		if _, err := url.ParseRequestURI(log.SlackWebhook); err == nil {
-			notifySlack(cmd.Description+" ... SUCCESS!", log.SlackWebhook, false, true)
-		}
-		if _, err := url.ParseRequestURI(log.MSTeamsWebhook); err == nil {
-			notifyMSTeams(cmd.Description+" ... SUCCESS!", log.MSTeamsWebhook, false, true)
-		}
-		return nil
+		return fmt.Errorf("%s failed: %w", cmd.Description, err)
 	}
+	log.Notice(res.output)
+	successMsg := "Finished: " + cmd.Description
+	log.Notice(successMsg)
+	if _, err := url.ParseRequestURI(log.SlackWebhook); err == nil {
+		notifySlack(cmd.Description+" ... SUCCESS!", log.SlackWebhook, false, true)
+	}
+	if _, err := url.ParseRequestURI(log.MSTeamsWebhook); err == nil {
+		notifyMSTeams(cmd.Description+" ... SUCCESS!", log.MSTeamsWebhook, false, true)
+	}
+	return nil
 }
 
 // printPlanCmds prints the actual commands that will be executed as part of a plan.

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -177,9 +177,9 @@ func (r *release) diff() (string, error) {
 
 	cmd := helmCmd(concat([]string{"diff", colorFlag, suppressDiffSecretsFlag}, diffContextFlag, r.getHelmArgsFor("diff")), "Diffing release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ]")
 
-	result := cmd.RetryExec(3)
-	if result.code != 0 {
-		return "", fmt.Errorf("Command returned with exit code: %d. And error message: %s ", result.code, result.errors)
+	result, err := cmd.RetryExec(3)
+	if err != nil {
+		return "", fmt.Errorf("command failed: %w", err)
 	}
 
 	return result.output, nil
@@ -253,9 +253,8 @@ func (r *release) label(storageBackend string, labels ...string) {
 		args = append(args, labels...)
 		cmd := kubectl(args, "Applying Helmsman labels to [ "+r.Name+" ] release")
 
-		result := cmd.Exec()
-		if result.code != 0 {
-			log.Fatal(result.errors)
+		if _, err := cmd.Exec(); err != nil {
+			log.Fatalf("%v", err)
 		}
 	}
 }
@@ -271,9 +270,8 @@ func (r *release) annotate(storageBackend string, annotations ...string) {
 		args = append(args, annotations...)
 		cmd := kubectl(args, "Applying Helmsman annotations to [ "+r.Name+" ] release")
 
-		result := cmd.Exec()
-		if result.code != 0 {
-			log.Fatal(result.errors)
+		if _, err := cmd.Exec(); err != nil {
+			log.Fatalf("%v", err)
 		}
 	}
 }

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -154,7 +154,7 @@ func (r *release) uninstall(p *plan, optionalNamespace ...string) {
 	}
 	priority := r.Priority
 	if p.ReverseDelete {
-		priority = priority * -1
+		priority *= -1
 	}
 
 	before, after := r.checkHooks("delete", ns)
@@ -177,12 +177,12 @@ func (r *release) diff() (string, error) {
 
 	cmd := helmCmd(concat([]string{"diff", colorFlag, suppressDiffSecretsFlag}, diffContextFlag, r.getHelmArgsFor("diff")), "Diffing release [ "+r.Name+" ] in namespace [ "+r.Namespace+" ]")
 
-	result, err := cmd.RetryExec(3)
+	res, err := cmd.RetryExec(3)
 	if err != nil {
 		return "", fmt.Errorf("command failed: %w", err)
 	}
 
-	return result.output, nil
+	return res.output, nil
 }
 
 // upgradeRelease upgrades an existing release with the specified values.yaml
@@ -254,7 +254,7 @@ func (r *release) label(storageBackend string, labels ...string) {
 		cmd := kubectl(args, "Applying Helmsman labels to [ "+r.Name+" ] release")
 
 		if _, err := cmd.Exec(); err != nil {
-			log.Fatalf("%v", err)
+			log.Fatal(err.Error())
 		}
 	}
 }
@@ -271,7 +271,7 @@ func (r *release) annotate(storageBackend string, annotations ...string) {
 		cmd := kubectl(args, "Applying Helmsman annotations to [ "+r.Name+" ] release")
 
 		if _, err := cmd.Exec(); err != nil {
-			log.Fatalf("%v", err)
+			log.Fatal(err.Error())
 		}
 	}
 }
@@ -309,39 +309,39 @@ func (r *release) getTimeout() []string {
 
 // getSetValues returns --set params to be used with helm install/upgrade commands
 func (r *release) getSetValues() []string {
-	result := []string{}
+	res := []string{}
 	for k, v := range r.Set {
-		result = append(result, "--set", k+"="+strings.Replace(v, ",", "\\,", -1)+"")
+		res = append(res, "--set", k+"="+strings.ReplaceAll(v, ",", "\\,")+"")
 	}
-	return result
+	return res
 }
 
 // getSetStringValues returns --set-string params to be used with helm install/upgrade commands
 func (r *release) getSetStringValues() []string {
-	result := []string{}
+	res := []string{}
 	for k, v := range r.SetString {
-		result = append(result, "--set-string", k+"="+strings.Replace(v, ",", "\\,", -1)+"")
+		res = append(res, "--set-string", k+"="+strings.ReplaceAll(v, ",", "\\,")+"")
 	}
-	return result
+	return res
 }
 
 // getSetFileValues returns --set-file params to be used with helm install/upgrade commands
 func (r *release) getSetFileValues() []string {
-	result := []string{}
+	res := []string{}
 	for k, v := range r.SetFile {
-		result = append(result, "--set-file", k+"="+strings.Replace(v, ",", "\\,", -1)+"")
+		res = append(res, "--set-file", k+"="+strings.ReplaceAll(v, ",", "\\,")+"")
 	}
-	return result
+	return res
 }
 
 // getWait returns a partial helm command containing the helm wait flag (--wait) if the wait flag for the release was set to true
 // Otherwise, retruns an empty string
 func (r *release) getWait() []string {
-	result := []string{}
+	res := []string{}
 	if r.Wait {
-		result = append(result, "--wait")
+		res = append(res, "--wait")
 	}
-	return result
+	return res
 }
 
 // getDesiredNamespace returns the namespace of a release
@@ -371,11 +371,11 @@ func (r *release) getHelmFlags() []string {
 
 // getPostRenderer returns the post-renderer Helm flag
 func (r *release) getPostRenderer() []string {
-	result := []string{}
+	args := []string{}
 	if r.PostRenderer != "" {
-		result = append(result, "--post-renderer", r.PostRenderer)
+		args = append(args, "--post-renderer", r.PostRenderer)
 	}
-	return result
+	return args
 }
 
 // getHelmArgsFor returns helm arguments for a specific helm operation

--- a/internal/app/release_files.go
+++ b/internal/app/release_files.go
@@ -83,7 +83,7 @@ func (r *release) getValuesFiles() []string {
 			if err := decryptSecret(r.SecretsFile); err != nil {
 				log.Fatal(err.Error())
 			}
-			r.SecretsFile = r.SecretsFile + ".dec"
+			r.SecretsFile += ".dec"
 		}
 		fileList = append(fileList, r.SecretsFile)
 	} else if len(r.SecretsFiles) > 0 {
@@ -98,7 +98,7 @@ func (r *release) getValuesFiles() []string {
 			if err := decryptSecret(r.SecretsFiles[i]); err != nil {
 				log.Fatal(err.Error())
 			}
-			r.SecretsFiles[i] = r.SecretsFiles[i] + ".dec"
+			r.SecretsFiles[i] += ".dec"
 		}
 		fileList = append(fileList, r.SecretsFiles...)
 	}

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -169,10 +169,8 @@ func (s *state) validate() error {
 			}
 		}
 
-	} else {
-		if s.Settings.ClusterURI != "" {
-			return errors.New("certificates validation failed -- kube context setup is required but no certificates stanza provided")
-		}
+	} else if s.Settings.ClusterURI != "" {
+		return errors.New("certificates validation failed -- kube context setup is required but no certificates stanza provided")
 	}
 
 	if (s.Settings.EyamlPrivateKeyPath != "" && s.Settings.EyamlPublicKeyPath == "") || (s.Settings.EyamlPrivateKeyPath == "" && s.Settings.EyamlPublicKeyPath != "") {

--- a/internal/app/state_test.go
+++ b/internal/app/state_test.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"fmt"
 	"os"
 	"testing"
 )
@@ -12,8 +11,8 @@ func setupTestCase(t *testing.T) func(t *testing.T) {
 	os.MkdirAll(os.TempDir()+"/helmsman-tests/myapp", os.ModePerm)
 	os.MkdirAll(os.TempDir()+"/helmsman-tests/dir-with space/myapp", os.ModePerm)
 	cmd := helmCmd([]string{"create", os.TempDir() + "/helmsman-tests/dir-with space/myapp"}, "creating an empty local chart directory")
-	if result := cmd.Exec(); result.code != 0 {
-		log.Fatal(fmt.Sprintf("Command returned with exit code: %d. And error message: %s ", result.code, result.errors))
+	if _, err := cmd.Exec(); err != nil {
+		log.Fatalf("Command failed: %v", err)
 	}
 
 	return func(t *testing.T) {

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -3,7 +3,6 @@ package app
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -20,6 +19,12 @@ import (
 	"github.com/Praqma/helmsman/internal/aws"
 	"github.com/Praqma/helmsman/internal/azure"
 	"github.com/Praqma/helmsman/internal/gcs"
+)
+
+var (
+	comment  = regexp.MustCompile("#(.*)$")
+	envVar   = regexp.MustCompile(`\${([a-zA-Z_][a-zA-Z0-9_-]*)}|\$([a-zA-Z_][a-zA-Z0-9_-]*)`)
+	ssmParam = regexp.MustCompile(`{{ssm: ([^~}]+)(~(true))?}}`)
 )
 
 // printMap prints to the console any map of string keys and values.
@@ -127,7 +132,7 @@ func substituteEnv(name string) string {
 	if strings.Contains(name, "$") {
 		// add $$ escaping for $ strings
 		os.Setenv("HELMSMAN_DOLLAR", "$")
-		return os.ExpandEnv(strings.Replace(name, "$$", "${HELMSMAN_DOLLAR}", -1))
+		return os.ExpandEnv(strings.ReplaceAll(name, "$$", "${HELMSMAN_DOLLAR}"))
 	}
 	return name
 }
@@ -138,8 +143,6 @@ func validateEnvVars(s string, filename string) error {
 	if !flags.skipValidation && strings.Contains(s, "$") {
 		log.Info("validating environment variables in " + filename)
 		var key string
-		comment, _ := regexp.Compile("#(.*)$")
-		envVar, _ := regexp.Compile(`\${([a-zA-Z_][a-zA-Z0-9_-]*)}|\$([a-zA-Z_][a-zA-Z0-9_-]*)`)
 		scanner := bufio.NewScanner(strings.NewReader(s))
 		for scanner.Scan() {
 			// remove spaces from the single line, then replace $$ with !? to prevent it from matching the regex,
@@ -169,8 +172,7 @@ func validateEnvVars(s string, filename string) error {
 // if the string does not contain '$', it is returned as is.
 func substituteSSM(name string) string {
 	if strings.Contains(name, "{{ssm: ") {
-		re := regexp.MustCompile(`{{ssm: ([^~}]+)(~(true))?}}`)
-		matches := re.FindAllSubmatch([]byte(name), -1)
+		matches := ssmParam.FindAllSubmatch([]byte(name), -1)
 		for _, match := range matches {
 			placeholder := string(match[0])
 			paramPath := string(match[1])
@@ -297,7 +299,7 @@ func notifySlack(content string, url string, failure bool, executing bool) bool 
 		pretext = "*No actions to perform!*"
 	} else if failure {
 		pretext = "*Failed to generate/execute a plan: *"
-		content = strings.Replace(content, "\"", "\\\"", -1)
+		content = strings.ReplaceAll(content, "\"", "\\\"")
 		contentSplit := strings.Split(content, "\n")
 		for i := range contentSplit {
 			if strings.TrimSpace(contentSplit[i]) != "" {
@@ -359,7 +361,7 @@ func notifySlack(content string, url string, failure bool, executing bool) bool 
 func replaceStringInFile(input []byte, outfile string, replacements map[string]string) {
 	output := input
 	for k, v := range replacements {
-		output = bytes.Replace(output, []byte(k), []byte(v), -1)
+		output = bytes.ReplaceAll(output, []byte(k), []byte(v))
 	}
 
 	if err := ioutil.WriteFile(outfile, output, 0o666); err != nil {
@@ -424,14 +426,14 @@ func decryptSecret(name string) error {
 		Description: "Decrypting " + name,
 	}
 
-	result, err := command.Exec()
+	res, err := command.Exec()
 	if err != nil {
 		return err
 	}
 	if !settings.EyamlEnabled {
 		_, fileNotFound := os.Stat(name + ".dec")
 		if fileNotFound != nil && !isOfType(name, []string{".dec"}) {
-			return errors.New(result.String())
+			return fmt.Errorf(res.String())
 		}
 	}
 
@@ -442,7 +444,7 @@ func decryptSecret(name string) error {
 		} else {
 			outfile = name + ".dec"
 		}
-		err := writeStringToFile(outfile, result.output)
+		err := writeStringToFile(outfile, res.output)
 		if err != nil {
 			log.Fatal("Can't write [ " + outfile + " ] file")
 		}
@@ -501,7 +503,7 @@ func notifyMSTeams(content string, url string, failure bool, executing bool) boo
 		pretext = "No actions to perform!"
 	} else if failure {
 		pretext = "Failed to generate/execute a plan:"
-		content = strings.Replace(content, "\"", "\\\"", -1)
+		content = strings.ReplaceAll(content, "\"", "\\\"")
 		contentSplit := strings.Split(content, "\n")
 		for i := range contentSplit {
 			if strings.TrimSpace(contentSplit[i]) != "" {

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -424,18 +424,15 @@ func decryptSecret(name string) error {
 		Description: "Decrypting " + name,
 	}
 
-	result := command.Exec()
+	result, err := command.Exec()
+	if err != nil {
+		return err
+	}
 	if !settings.EyamlEnabled {
 		_, fileNotFound := os.Stat(name + ".dec")
 		if fileNotFound != nil && !isOfType(name, []string{".dec"}) {
-			return errors.New(result.errors)
+			return errors.New(result.String())
 		}
-	}
-
-	if result.code != 0 {
-		return errors.New(result.errors)
-	} else if result.errors != "" {
-		return errors.New(result.errors)
 	}
 
 	if settings.EyamlEnabled {


### PR DESCRIPTION
Per https://github.com/Praqma/helmsman/issues/598

But I ran into something that should probably be fixed first: https://github.com/Praqma/helmsman/pull/600

Based on this and that, I won't be looking to merge this until I add some (locally-passing!) tests. In particular the constant parsing of `ExitStatus.output` is a bit worrisome and merits some more tests (I saw some JSON unmarshaling!). I don't think the error exit status is parsed.