### PR TITLE
do not "download" local files

### DIFF
--- a/internal/app/kube_helpers.go
+++ b/internal/app/kube_helpers.go
@@ -221,7 +221,7 @@ func createContext(s *state) error {
 	// bearer token
 	tokenPath := "bearer.token"
 	if s.Settings.BearerToken && s.Settings.BearerTokenPath != "" {
-		downloadFile(s.Settings.BearerTokenPath, "", tokenPath)
+		tokenPath = downloadFile(s.Settings.BearerTokenPath, "", tokenPath)
 	}
 
 	// connecting to the cluster


### PR DESCRIPTION
I've been encountering issues locally running helmsman that I think are a result of a failed copy of local files.
The files are first copied from once from the location defined in `certificates: { caCert: "/path/to/ca.crt" }` to a temporary location, and then again from the temporary location to the current directory at `ca.crt`. the latter copy creates a file of 0 bytes in size, causing `kubectl` commands to fail. This either means `to.Close()` is returning an error (this error is ignored by the code) or `io.Copy()` is copying 0 bytes. I was going to add some debug logging to `copyFile`, but I realized that it probably doesn't make sense to "download" a local file in the first place. In running some tests, the local files are "downloaded" (copied) at least twice for no discernible reason. 

This patch takes a more sensible approach to local file management:
- detect if a file is a local file
- try to resolve its absolute path (if a relative path was given)
- try to stat the file, to make sure it exists
- return the absolute path to the file