### PR TITLE
fix: --server-dry-run was deprecated in kubectl 1.18

### DIFF
--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -154,7 +154,7 @@ func (c *cli) parse() {
 		log.Fatal("this version of Helmsman does not work with helm releases older than 3.0.0")
 	}
 
-	kubectlVersion := strings.TrimSpace(strings.SplitN(getKubectlClientVersion(), ": ", 2)[1])
+	kubectlVersion := getKubectlVersion()
 	log.Verbose("kubectl client version: " + kubectlVersion)
 
 	if len(c.files) == 0 {

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/Praqma/helmsman/internal/aws"
 	"github.com/Praqma/helmsman/internal/azure"
 	"github.com/Praqma/helmsman/internal/gcs"
@@ -466,6 +467,19 @@ func isValidFile(filePath string, allowedFileTypes []string) error {
 		return fmt.Errorf("%s must be of one the following file formats: %s", filePath, strings.Join(allowedFileTypes, ", "))
 	}
 	return nil
+}
+
+func checkVersion(version, constraint string) bool {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return false
+	}
+
+	jsonConstraint, err := semver.NewConstraint(constraint)
+	if err != nil {
+		return false
+	}
+	return jsonConstraint.Check(v)
 }
 
 // notify MSTeams sends a JSON formatted message to MSTeams channel over a webhook url


### PR DESCRIPTION
this should fix #607 