### PR TITLE
Pass error to user if we fail to correctly pull or export oci chart images

### DIFF
--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -211,7 +211,9 @@ func downloadFile(file string, dir string, outfile string) string {
 	case "oci":
 		dest := filepath.Dir(outfile)
 		fileName := strings.Split(filepath.Base(file), ":")[0]
-		helmExportChart(strings.ReplaceAll(file, "oci://", ""), dest)
+		if err := helmExportChart(strings.ReplaceAll(file, "oci://", ""), dest); err != nil {
+			log.Fatal(err.Error())
+		}
 		return filepath.Join(dest, fileName)
 	case "https", "http":
 		if err := downloadFileFromURL(file, outfile); err != nil {


### PR DESCRIPTION
Hiya,

This PR just sets up helmsman to throw if its unable to save or export OCI-based charts

Thanks!