### PR TITLE
Add skipIgnoredApps option to DSF Settings block

### DIFF
--- a/docs/desired_state_specification.md
+++ b/docs/desired_state_specification.md
@@ -118,6 +118,7 @@ The following options can be skipped if your kubectl context is already created 
 - **eyamlPublicKeyPath** : if set with path to the eyaml public key file, it will use it instead of looking for default one in ./keys directory relative to where Helmsman were run. It needs to be defined in conjunction with eyamlPrivateKeyPath.
 - **globalHooks** : defines global lifecycle hooks to apply yaml manifest before and/or after different helmsman operations. Check [here](how_to/apps/lifecycle_hooks.md) for more details.
 - **globalMaxHistory** : defines the **global** maximum number of helm revisions state (secrets/configmap) to keep. Releases can override this global value by setting `maxHistory`. If both are not set or are set to `0`, it is defaulted to 10.
+- **skipIgnoredApps** : if set to true apps, that would normally be listed in the plan as `ignored`, will be skipped. They won't show up on the plan output and won't be considered in decisions. This is especially useful when using `-target` or `-group` flags with significant amount of apps where most of them show up as `ignored` in the plan output making it hard to read.
 
 Example:
 

--- a/internal/app/decision_maker.go
+++ b/internal/app/decision_maker.go
@@ -77,7 +77,7 @@ func (cs *currentState) makePlan(s *state) *plan {
 				<-sem
 			}()
 			r.checkChartDepUpdate()
-			cs.decide(r, s.Namespaces[r.Namespace], p, c)
+			cs.decide(r, s.Namespaces[r.Namespace], p, c, s.Settings)
 		}(r, s.ChartInfo[r.Chart][r.Version])
 	}
 	wg.Wait()
@@ -87,10 +87,12 @@ func (cs *currentState) makePlan(s *state) *plan {
 
 // decide makes a decision about what commands (actions) need to be executed
 // to make a release section of the desired state come true.
-func (cs *currentState) decide(r *release, n *namespace, p *plan, c *chartInfo) {
+func (cs *currentState) decide(r *release, n *namespace, p *plan, c *chartInfo, settings config) {
 	// check for presence in defined targets or groups
 	if !r.isConsideredToRun() {
-		p.addDecision("Release [ "+r.Name+" ] ignored", r.Priority, ignored)
+		if !settings.SkipIgnoredApps {
+			p.addDecision("Release [ "+r.Name+" ] ignored", r.Priority, ignored)
+		}
 		return
 	}
 

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -29,6 +29,7 @@ type config struct {
 	EyamlPublicKeyPath           string                 `yaml:"eyamlPublicKeyPath"`
 	GlobalHooks                  map[string]interface{} `yaml:"globalHooks"`
 	GlobalMaxHistory             int                    `yaml:"globalMaxHistory"`
+	SkipIgnoredApps              bool                   `yaml:"skipIgnoredApps"`
 }
 
 // state type represents the desired state of applications on a k8s cluster.


### PR DESCRIPTION
Adding `skipIgnoredApps` option in Settings block of DSF file.
When defined as `true`, output plan will be limited to the apps with decision different than `ignored`. This will help in multiple helmsman runs when `-target` or `-group` flag is used on DSF having significant number of apps causing the plan to contain tons of `ignored` lines making the plan hard to read.
What do you think?