### PR TITLE
Diff exit code

### DIFF
--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -259,7 +259,9 @@ func (c *cli) readState(s *state) error {
 	if len(c.spec) > 0 {
 
 		sp := new(StateFiles)
-		sp.specFromYAML(c.spec)
+		if err := sp.specFromYAML(c.spec); err != nil {
+			return fmt.Errorf("error parsing spec file: %w", err)
+		}
 
 		for _, val := range sp.StateFiles {
 			fo := fileOption{}

--- a/internal/app/decision_maker_test.go
+++ b/internal/app/decision_maker_test.go
@@ -112,7 +112,9 @@ func Test_inspectUpgradeScenario(t *testing.T) {
 
 			// Act
 			c, _ := getChartInfo(tt.args.r.Chart, tt.args.r.Version)
-			cs.inspectUpgradeScenario(tt.args.r, &outcome, c)
+			if err := cs.inspectUpgradeScenario(tt.args.r, &outcome, c); err != nil {
+				t.Errorf("inspectUpgradeScenario() error = %v", err)
+			}
 			got := outcome.Decisions[0].Type
 			t.Log(outcome.Decisions[0].Description)
 

--- a/internal/app/helm_helpers_test.go
+++ b/internal/app/helm_helpers_test.go
@@ -72,7 +72,7 @@ func Test_getChartInfo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := getChartInfo(tt.args.r.Chart, tt.args.r.Version)
 			if err != nil && tt.want != nil {
-				t.Errorf("getChartInfo() = Unexpected error: %w", err)
+				t.Errorf("getChartInfo() = Unexpected error: %v", err)
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getChartInfo() = %v, want %v", got, tt.want)

--- a/internal/app/kube_helpers.go
+++ b/internal/app/kube_helpers.go
@@ -78,10 +78,10 @@ func labelNamespace(ns string, labels map[string]string, authoritative bool) {
 		// ignore default k8s namespace label from being removed
 		delete(nsLabels, "kubernetes.io/metadata.name")
 		// ignore every label defined in DSF for the namespace from being removed
-		for definedLabelKey, _ := range labels {
+		for definedLabelKey := range labels {
 			delete(nsLabels, definedLabelKey)
 		}
-		for label, _ := range nsLabels {
+		for label := range nsLabels {
 			args = append(args, label+"-")
 		}
 	}

--- a/internal/app/spec_state_test.go
+++ b/internal/app/spec_state_test.go
@@ -31,7 +31,10 @@ func Test_specFromYAML(t *testing.T) {
 		},
 	}
 
-	teardownTestCase := setupStateFileTestCase(t)
+	teardownTestCase, err := setupStateFileTestCase(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer teardownTestCase(t)
 	for _, tt := range tests {
 		// os.Args = append(os.Args, "-f ../../examples/example.yaml")
@@ -72,7 +75,10 @@ func Test_specFileSort(t *testing.T) {
 		},
 	}
 
-	teardownTestCase := setupStateFileTestCase(t)
+	teardownTestCase, err := setupStateFileTestCase(t)
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer teardownTestCase(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/app/state_files_test.go
+++ b/internal/app/state_files_test.go
@@ -6,14 +6,17 @@ import (
 	"testing"
 )
 
-func setupStateFileTestCase(t *testing.T) func(t *testing.T) {
+func setupStateFileTestCase(t *testing.T) (func(t *testing.T), error) {
 	t.Log("setup test case")
-	os.MkdirAll(tempFilesDir, 0o755)
+	if err := os.MkdirAll(tempFilesDir, 0o755); err != nil {
+		t.Errorf("setupStateFileTestCase(), failed to create temp files dir: %v", err)
+		return nil, err
+	}
 
 	return func(t *testing.T) {
 		t.Log("teardown test case")
 		os.RemoveAll(tempFilesDir)
-	}
+	}, nil
 }
 
 func Test_fromTOML(t *testing.T) {
@@ -45,7 +48,10 @@ func Test_fromTOML(t *testing.T) {
 	os.Setenv("ORG_PATH", "sample")
 	os.Setenv("VALUE", "sample")
 
-	teardownTestCase := setupStateFileTestCase(t)
+	teardownTestCase, err := setupStateFileTestCase(t)
+	if err != nil {
+		t.Errorf("setupStateFileTestCase(), got: %v", err)
+	}
 	defer teardownTestCase(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -97,7 +103,10 @@ func Test_fromTOML_Expand(t *testing.T) {
 	os.Setenv("ORG_PATH", "sample")
 	os.Setenv("VALUE", "sample")
 
-	teardownTestCase := setupStateFileTestCase(t)
+	teardownTestCase, err := setupStateFileTestCase(t)
+	if err != nil {
+		t.Errorf("setupStateFileTestCase(), got: %v", err)
+	}
 	defer teardownTestCase(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -179,7 +188,10 @@ func Test_fromYAML(t *testing.T) {
 	os.Setenv("VALUE", "sample")
 	os.Setenv("ORG_PATH", "sample")
 
-	teardownTestCase := setupStateFileTestCase(t)
+	teardownTestCase, err := setupStateFileTestCase(t)
+	if err != nil {
+		t.Errorf("setupStateFileTestCase(), got: %v", err)
+	}
 	defer teardownTestCase(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -225,13 +237,17 @@ func Test_fromYAML_UnsetVars(t *testing.T) {
 		},
 	}
 
-	teardownTestCase := setupStateFileTestCase(t)
+	teardownTestCase, err := setupStateFileTestCase(t)
+	if err != nil {
+		t.Errorf("setupStateFileTestCase(), got: %v", err)
+	}
 	defer teardownTestCase(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.targetVar == "ORG_PATH" {
+			switch tt.targetVar {
+			case "ORG_PATH":
 				os.Setenv("VALUE", "sample")
-			} else if tt.targetVar == "VALUE" {
+			case "VALUE":
 				os.Setenv("ORG_PATH", "sample")
 			}
 			err := tt.args.s.fromYAML(tt.args.file)
@@ -282,7 +298,10 @@ func Test_fromYAML_Expand(t *testing.T) {
 	os.Setenv("ORG_PATH", "sample")
 	os.Setenv("VALUE", "sample")
 
-	teardownTestCase := setupStateFileTestCase(t)
+	teardownTestCase, err := setupStateFileTestCase(t)
+	if err != nil {
+		t.Errorf("setupStateFileTestCase(), got: %v", err)
+	}
 	defer teardownTestCase(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
`kubectl diff` returns 1 when there's a diff and the command was always being retried, this should fix it and it also adds some missing error checks.