### PR TITLE
Fix broken links in examples

### DIFF
--- a/docs/how_to/apps/basic.md
+++ b/docs/how_to/apps/basic.md
@@ -6,7 +6,7 @@ version: v3.0.0-beta5
 
 ## Install releases
 
-You can run helmsman with the [example.toml](https://github.com/Praqma/helmsman/blob/master/example.toml) or [example.yaml](https://github.com/Praqma/helmsman/blob/master/example.yaml) file.
+You can run helmsman with the [example.toml](https://github.com/Praqma/helmsman/blob/master/examples/example.toml) or [example.yaml](https://github.com/Praqma/helmsman/blob/master/examples/example.yaml) file.
 
 ```shell
 $ helmsman --apply -f example.toml


### PR DESCRIPTION
Links were incorrect and getting 404s for `example.yaml` and `example.toml`.  Looks like they might have moved at some point.  