### PR TITLE
Option for checking for available updates for app charts

### DIFF
--- a/docs/cmd_reference.md
+++ b/docs/cmd_reference.md
@@ -101,4 +101,7 @@ This lists available CMD options in Helmsman:
   `--update-deps`
         run 'helm dep up' for local chart
 
+  `--check-for-chart-updates`
+        compares the chart versions in the state file to the latest versions in the chart repositories and shows available updates
+
   `--v`    show the version.

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -101,6 +101,7 @@ type cli struct {
 	alwaysUpgrade         bool
 	noUpdate              bool
 	kubectlDiff           bool
+	checkForChartUpdates  bool
 }
 
 func printUsage() {
@@ -150,6 +151,7 @@ func (c *cli) parse() {
 	flag.BoolVar(&c.alwaysUpgrade, "always-upgrade", false, "upgrade release even if no changes are found")
 	flag.BoolVar(&c.noUpdate, "no-update", false, "skip updating helm repos")
 	flag.BoolVar(&c.kubectlDiff, "kubectl-diff", false, "use kubectl diff instead of helm diff. Defalts to false if the helm diff plugin is installed.")
+	flag.BoolVar(&c.checkForChartUpdates, "check-for-chart-updates", false, "compares the version in the state file to the latest version in the chart repository")
 	flag.Usage = printUsage
 	flag.Parse()
 

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -151,7 +151,7 @@ func (c *cli) parse() {
 	flag.BoolVar(&c.alwaysUpgrade, "always-upgrade", false, "upgrade release even if no changes are found")
 	flag.BoolVar(&c.noUpdate, "no-update", false, "skip updating helm repos")
 	flag.BoolVar(&c.kubectlDiff, "kubectl-diff", false, "use kubectl diff instead of helm diff. Defalts to false if the helm diff plugin is installed.")
-	flag.BoolVar(&c.checkForChartUpdates, "check-for-chart-updates", false, "compares the version in the state file to the latest version in the chart repository")
+	flag.BoolVar(&c.checkForChartUpdates, "check-for-chart-updates", false, "compares the chart versions in the state file to the latest versions in the chart repositories and shows available updates")
 	flag.Usage = printUsage
 	flag.Parse()
 

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -103,6 +103,12 @@ func Main() {
 		s.updateContextLabels()
 	}
 
+	if flags.checkForChartUpdates {
+		for _, r := range s.Apps {
+			r.checkChartForUpdates()
+		}
+	}
+
 	log.Info("Preparing plan")
 	cs := s.getCurrentState()
 	p := cs.makePlan(&s)

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -429,6 +429,23 @@ func (r *release) checkChartDepUpdate() {
 	}
 }
 
+func (r *release) checkChartForUpdates() {
+	if !r.isConsideredToRun() {
+		return
+	}
+
+	if flags.checkForChartUpdates && !isLocalChart(r.Chart) {
+		chartInfo, err := getChartInfo(r.Chart, ">= "+r.Version)
+		if err != nil {
+			log.Fatal("Couldn't check version for " + r.Chart + ": " + err.Error())
+		}
+
+		if checkVersion(r.Version, "< "+chartInfo.Version) {
+			log.Infof("Newer version for release %s, chart %s found: current %s, latest %s", r.Name, r.Chart, r.Version, chartInfo.Version)
+		}
+	}
+}
+
 // overrideNamespace overrides a release defined namespace with a new given one
 func (r *release) overrideNamespace(newNs string) {
 	log.Info("Overriding namespace for app:  " + r.Name)


### PR DESCRIPTION
Hi!

Here's a small feature for running a check for available updates for charts used in the states apps.

It's often easier to keep up with the chart updates when moving in smaller steps, but keeping up on what could be updated is an annoying chore. This feature helps a bit with the tracking. 