### PR TITLE
Support arm64 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ test: deps vet repo ## Run unit tests
 .PHONY: test
 
 cross: deps ## Create binaries for all OSs
-	@gox -os '!freebsd !netbsd' -arch '!arm' -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags '-X main.Version=${TAG}-${DATE}' ./...
+	@gox -os 'windows linux darwin' -arch 'arm64 amd64' -output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" -ldflags '-X main.Version=${TAG}-${DATE}' ./...
 .PHONY: cross
 
 release: ## Generate a new release


### PR DESCRIPTION
This PR updates the cross compilation task to add support for Linux/MacOS arm64 builds.

With this PR the following builds are created:

```
% make cross
Number of parallel builds: 9

-->    darwin/amd64: github.com/Praqma/helmsman/cmd/helmsman
-->     linux/arm64: github.com/Praqma/helmsman/cmd/helmsman
-->   windows/amd64: github.com/Praqma/helmsman/cmd/helmsman
-->    darwin/arm64: github.com/Praqma/helmsman/cmd/helmsman
-->     linux/amd64: github.com/Praqma/helmsman/cmd/helmsman
```