### PR TITLE
Add arm64 arch option to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,4 +11,5 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm64
     main: ./cmd/helmsman/main.go   


### PR DESCRIPTION
This change is a follow up to previously merged PR #642 and ensures arm64 builds will be published when running `make release`.

I tested running `make cross` and `make release` successfully on my own fork - see https://github.com/mixja/helmsman/releases.