### PR TITLE
fix: .env files should overwrite env vars

### DIFF
--- a/docs/cmd_reference.md
+++ b/docs/cmd_reference.md
@@ -36,7 +36,8 @@ This lists available CMD options in Helmsman:
         apply the dry-run (do not update) option for helm commands.
 
   `-e value`
-        file(s) to load environment variables from (default .env), may be supplied more than once.
+        additional file(s) to load environment variables from, may be supplied more than once, it extends default .env file lookup, every next file takes precedence over previous ones in case of having the same environment variables defined.
+        If a `.env` file exists, it will be loaded by default, if additional env files are specified using the `-e` flag, the environment file will be loaded in order where the last file will take precedence.
 
   `-f value`
         desired state file name(s), may be supplied more than once to merge state files.


### PR DESCRIPTION
This solves #645 and makes the loading of `.env` files behave as I would expect them to but it does change the existing behaviour quite significantly:

* Before the default `.env` file would only be loaded if no env files were explicitly passed through the `-e` flag, now it will always be loaded first if present
* Before loading env files would not overwrite any env variable that had already been set before, now it does so when loading multiple files if a variable is set more than once the value from the last file to be loaded will take precedence.
* Before the first file would take precedence, now, the last one will.

I've checked the documentation and there's no mention to what is the expected behaviour.

I think this behaviour is more natural and intuitive but what do you think @mkubaczyk 