### PR TITLE
Add -exclude-target and -exclude-group cli options

### DIFF
--- a/docs/cmd_reference.md
+++ b/docs/cmd_reference.md
@@ -96,8 +96,14 @@ This lists available CMD options in Helmsman:
   `--target`
         limit execution to specific app.
 
+  `--exclude-target`
+        exclude specific app from execution.
+
   `--group`
         limit execution to specific group of apps.
+
+  `--exclude-group`
+        exclude specific group of apps from execution.
 
   `--update-deps`
         run 'helm dep up' for local chart

--- a/docs/how_to/README.md
+++ b/docs/how_to/README.md
@@ -54,5 +54,6 @@ It is recommended that you also check the [DSF spec](../desired_state_specificat
   - [Merge multiple desired state files](misc/merge_desired_state_files.md)
   - [Limit Helmsman deployment to specific apps](misc/limit-deployment-to-specific-apps.md)
   - [Limit Helmsman deployment to specific group of apps](misc/limit-deployment-to-specific-group-of-apps.md)
+  - [Exclude apps or groups from Helmsman deployment](misc/exclude-apps-or-groups-from-deployment.md)
   - [Use hiera-eyaml as secrets encryption backend](settings/use-hiera-eyaml-as-secrets-encryption.md)
   - [Use DRY-ed code](misc/use-dry-code.md)

--- a/docs/how_to/misc/exclude-apps-or-groups-from-deployment.md
+++ b/docs/how_to/misc/exclude-apps-or-groups-from-deployment.md
@@ -1,0 +1,50 @@
+---
+version: v3.10.0
+---
+
+# Exclude specific apps or groups from execution
+
+Starting from v3.10.0, Helmsman allows you to pass the `--exclude-target` or `--exclude-group` flag multiple times 
+to specify which apps or groups should be excluded from execution.
+Thanks to this one can exclude specific applications among all defined for an environment.
+
+## Example
+
+Having environment defined with such apps:
+
+example.yaml:
+
+```yaml
+# ...
+apps:
+    jenkins:
+      namespace: "staging" # maps to the namespace as defined in namespaces above
+      enabled: true # change to false if you want to delete this app release empty: false:
+      chart: "jenkins/jenkins" # changing the chart name means delete and recreate this chart
+      version: "2.15.1" # chart version
+
+    artifactory:
+      namespace: "production" # maps to the namespace as defined in namespaces above
+      enabled: true # change to false if you want to delete this app release empty: false:
+      chart: "jfrog/artifactory" # changing the chart name means delete and recreate this chart
+      version: "11.4.2" # chart version
+# ...
+```
+
+running Helmsman with `-f example.yaml` would result in checking state and invoking deployment for both jenkins and artifactory application.
+
+With `--exclude-target` flag in command like
+
+```shell
+helmsman -f example.yaml --exclude-target artifactory ...
+```
+
+one can execute Helmsman's environment defined with example.yaml limited to only one `jenkins` app by excluding second one - `artifactory` from the execution.
+
+Multiple applications can be excluded with `--exclude-target`, like
+
+```shell
+helmsman -f example.yaml --exclude-target artifactory --exclude-target jenkins ...
+```
+
+Same rules apply for `--exclude-groups`.

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -68,7 +68,9 @@ type cli struct {
 	spec                  string
 	envFiles              stringArray
 	target                stringArray
+	targetExcluded        stringArray
 	group                 stringArray
+	groupExcluded         stringArray
 	kubeconfig            string
 	apply                 bool
 	destroy               bool
@@ -121,6 +123,8 @@ func (c *cli) parse() {
 	flag.Var(&c.envFiles, "e", "additional file(s) to load environment variables from, may be supplied more than once, it extends default .env file lookup, every next file takes precedence over previous ones in case of having the same environment variables defined")
 	flag.Var(&c.target, "target", "limit execution to specific app.")
 	flag.Var(&c.group, "group", "limit execution to specific group of apps.")
+	flag.Var(&c.targetExcluded, "exclude-target", "exclude specific app from execution.")
+	flag.Var(&c.groupExcluded, "exclude-group", "exclude specific group of apps from execution.")
 	flag.IntVar(&c.diffContext, "diff-context", -1, "number of lines of context to show around changes in helm diff output")
 	flag.IntVar(&c.parallel, "p", 1, "max number of concurrent helm releases to run")
 	flag.StringVar(&c.spec, "spec", "", "specification file name, contains locations of desired state files to be merged")
@@ -277,7 +281,7 @@ func (c *cli) readState(s *state) error {
 
 	// read the TOML/YAML desired state file
 	s.build(c.files)
-	s.disableUntargetedApps(c.group, c.target)
+	s.disableApps(c.group, c.target, c.groupExcluded, c.targetExcluded)
 
 	if c.skipIgnoredApps {
 		s.Settings.SkipIgnoredApps = true

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -295,8 +295,24 @@ func (s *state) overrideAppsNamespace(newNs string) {
 	}
 }
 
-// get only those Apps that exist in TargetMap
-func (s *state) disableUntargetedApps(groups, targets []string) {
+// disable Apps defined as excluded by either their name or their group
+// then get only those Apps that exist in TargetMap
+func (s *state) disableApps(groups, targets, groupsExcluded, targetsExcluded []string) {
+excludeAppsLoop:
+	for appName, app := range s.Apps {
+		for _, groupExcluded := range groupsExcluded {
+			if app.Group == groupExcluded {
+				app.Disable()
+				continue excludeAppsLoop
+			}
+		}
+		for _, targetExcluded := range targetsExcluded {
+			if appName == targetExcluded {
+				app.Disable()
+				continue excludeAppsLoop
+			}
+		}
+	}
 	if s.TargetMap == nil {
 		s.TargetMap = make(map[string]bool)
 	}

--- a/internal/app/state_test.go
+++ b/internal/app/state_test.go
@@ -509,7 +509,7 @@ func Test_state_getReleaseChartsInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			stt := &state{Apps: tt.args.apps}
-			stt.disableUntargetedApps(tt.groupFlag, tt.targetFlag)
+			stt.disableApps(tt.groupFlag, tt.targetFlag, []string{}, []string{})
 			err := stt.getReleaseChartsInfo()
 			switch err.(type) {
 			case nil:


### PR DESCRIPTION
This PR adds `-exclude-target` and `-exclude-group` CLI flags so one can exclude specific apps by either their names or groups from execution no matter if `-target` and `-group` flags were used or not. This came useful for me when trying to redeploy whole environment without one or two apps that I had to take care differently.
It works for every possible case as I'm disabling those apps on an early stage even before considering `-target` or `-group` flags.