### PR TITLE
Add error handling to state building from files

### DIFF
--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -262,7 +262,6 @@ func (c *cli) readState(s *state) error {
 	_ = os.MkdirAll(tempFilesDir, 0o755)
 
 	if len(c.spec) > 0 {
-
 		sp := new(StateFiles)
 		if err := sp.specFromYAML(c.spec); err != nil {
 			return fmt.Errorf("error parsing spec file: %w", err)
@@ -280,7 +279,10 @@ func (c *cli) readState(s *state) error {
 	}
 
 	// read the TOML/YAML desired state file
-	s.build(c.files)
+	if err := s.build(c.files); err != nil {
+		return fmt.Errorf("error building the state from files: %w", err)
+	}
+
 	s.disableApps(c.group, c.target, c.groupExcluded, c.targetExcluded)
 
 	if c.skipIgnoredApps {


### PR DESCRIPTION
I noticed that an invalid application configuration didn't error out when creating a plan. Instead it would just exit and say that no applications were found. Specifically, I had `preInstall` under the application instead of under `my-app.hooks`. Digging in, it appears that errors from parsing were being returned, but the `build` method on the state wasn't handling the error being return. This simply handles the error and returns it so that it is correctly outputted to the screen so the issue is shown to the user instead of being swallowed.