### PR TITLE
Add detailed exit code feature

### DIFF
--- a/docs/cmd_reference.md
+++ b/docs/cmd_reference.md
@@ -26,6 +26,9 @@ This lists available CMD options in Helmsman:
   `--destroy`
         delete all deployed releases.
 
+  `-detailed-exit-code`
+        returns a detailed exit code (0 - no changes, 1 - error, 2 - changes present)
+
   `--diff-context num`
         number of lines of context to show around changes in helm diff output.
 

--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -90,6 +90,7 @@ type cli struct {
 	substEnvValues        bool
 	noSSMSubst            bool
 	substSSMValues        bool
+	detailedExitCode      bool
 	updateDeps            bool
 	forceUpgrades         bool
 	renameReplace         bool
@@ -144,6 +145,7 @@ func (c *cli) parse() {
 	flag.BoolVar(&c.skipValidation, "skip-validation", false, "skip desired state validation")
 	flag.BoolVar(&c.keepUntrackedReleases, "keep-untracked-releases", false, "keep releases that are managed by Helmsman from the used DSFs in the command, and are no longer tracked in your desired state.")
 	flag.BoolVar(&c.showDiff, "show-diff", false, "show helm diff results. Can expose sensitive information.")
+	flag.BoolVar(&c.detailedExitCode, "detailed-exit-code", false, "returns a detailed exit code (0 - no changes, 1 - error, 2 - changes present)")
 	flag.BoolVar(&c.noEnvSubst, "no-env-subst", false, "turn off environment substitution globally")
 	flag.BoolVar(&c.substEnvValues, "subst-env-values", false, "turn on environment substitution in values files.")
 	flag.BoolVar(&c.noSSMSubst, "no-ssm-subst", false, "turn off SSM parameter substitution globally")

--- a/internal/app/main.go
+++ b/internal/app/main.go
@@ -14,6 +14,11 @@ const (
 	resourcePool       = 10
 )
 
+const (
+	exitCodeSucceed            = 0
+	exitCodeSucceedWithChanges = 2
+)
+
 var (
 	flags      cli
 	settings   *config
@@ -127,4 +132,12 @@ func Main() {
 	if flags.apply || flags.dryRun || flags.destroy {
 		p.exec()
 	}
+
+	exitCode := exitCodeSucceed
+
+	if flags.detailedExitCode && len(p.Commands) > 0 {
+		exitCode = exitCodeSucceedWithChanges
+	}
+
+	os.Exit(exitCode)
 }


### PR DESCRIPTION
Feature request - #527

## What
The PR adds a new flag `detailed-exit-code` that makes the CLI return more granular exit code based on a execution plan. The feature is useful for building some CI logic on top of it.


## Testing
I tested the feature locally:

### show-diff with detailed-exit-code
```
> ./helmsman -show-diff -detailed-exit-code -no-fancy -f examples/minimal-example.yaml
2022-06-03 23:18:55 NOTICE: -------- PLAN starts here --------------
2022-06-03 23:18:55 NOTICE: Release [ jenkins ] in namespace [ staging ] will be installed using version [ 2.15.1 ] -- priority: 0
2022-06-03 23:18:55 NOTICE: Release [ artifactory ] in namespace [ staging ] will be installed using version [ 11.4.2 ] -- priority: 0
2022-06-03 23:18:55 NOTICE: -------- PLAN ends here --------------

> echo $?
2

```

### show-diff without detailed-exit-code
```
> ./helmsman -show-diff -no-fancy -f examples/minimal-example.yaml
...
2022-06-03 23:19:28 NOTICE: -------- PLAN starts here --------------
2022-06-03 23:19:28 NOTICE: Release [ artifactory ] in namespace [ staging ] will be installed using version [ 11.4.2 ] -- priority: 0
2022-06-03 23:19:28 NOTICE: Release [ jenkins ] in namespace [ staging ] will be installed using version [ 2.15.1 ] -- priority: 0
2022-06-03 23:19:28 NOTICE: -------- PLAN ends here --------------

> echo $?                                                     
0
```


