### PR TITLE
fix: check charts in all previous helmRepos

### DIFF
--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -46,6 +46,7 @@ type state struct {
 	AppsTemplates          map[string]*release   `yaml:"appsTemplates,omitempty"`
 	TargetMap              map[string]bool
 	ChartInfo              map[string]map[string]*chartInfo
+	mergedState            *state
 }
 
 func (s *state) init() {


### PR DESCRIPTION
Historically repeating helmRepos in multiple DSF files used to be causing issues. That forced us to push helmRepos into a shared DSF file which is supposed to hold our helmRepos.

After recent changes/refactors that behavior is changed unintentionally, and helmsman started to check if a chart is from a repo by checking its repo name only in the current DSF that's being parsed.

This change lets the DSF files share the helmRepos.

Example case without this PR:

Let's say we have these dsf files:

`shared-dsf.yaml` (defines `myrepo`)
```yaml
helmRepos:
  myrepo: https://...
```

`other-dsf.yaml` (refers a chart from `myrepo`)
```yaml
apps:
  test:
    chart: myrepo/test
```

And we run this command:
```shell
helmsman -apply -f shared-dsf.yaml -f other-dsf.yaml
```

While it should try to use the `test` chart from `myrepo` (helmsman used to do this for a long while), it instead fails with an error message like this:
```
CRITICAL: could not stat /abs/path/to/myrepo/test : stat /abs/path/to/myrepo/test: no such file or directory
```