### PR TITLE
refactor: use sigs.k8s.io/yaml and json tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/subosito/gotenv v1.4.0
 	golang.org/x/net v0.0.0-20220617184016-355a448f1bc9
-	gopkg.in/yaml.v2 v2.4.0
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -46,4 +46,5 @@ require (
 	google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad // indirect
 	google.golang.org/grpc v1.47.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,7 @@ github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWH
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -732,3 +733,5 @@ honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/internal/app/helm_helpers.go
+++ b/internal/app/helm_helpers.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"github.com/Masterminds/semver"
 	"github.com/Praqma/helmsman/internal/gcs"
@@ -19,8 +19,8 @@ type helmRepo struct {
 }
 
 type ChartInfo struct {
-	Name    string `yaml:"name"`
-	Version string `yaml:"version"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 // helmCmd prepares a helm command to be executed

--- a/internal/app/kube_helpers.go
+++ b/internal/app/kube_helpers.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // addNamespaces creates a set of namespaces in your k8s cluster.

--- a/internal/app/namespace.go
+++ b/internal/app/namespace.go
@@ -7,32 +7,32 @@ import (
 // Resources type
 type Resources struct {
 	// CPU is the number of CPU cores
-	CPU string `yaml:"cpu,omitempty"`
+	CPU string `json:"cpu,omitempty"`
 	// Memory is the amount of memory
-	Memory string `yaml:"memory,omitempty"`
+	Memory string `json:"memory,omitempty"`
 }
 
 // custom resource type
 type CustomResource struct {
 	// Name of the custom resource
-	Name string `yaml:"name,omitempty"`
+	Name string `json:"name,omitempty"`
 	// Value of the custom resource
-	Value string `yaml:"value,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 // Limit represents a resource limit
 type Limit struct {
 	// Max defines the resource limits
-	Max Resources `yaml:"max,omitempty"`
+	Max Resources `json:"max,omitempty"`
 	// Min defines the resource request
-	Min Resources `yaml:"min,omitempty"`
+	Min Resources `json:"min,omitempty"`
 	// Default stes resource limits to pods without defined resource limits
-	Default Resources `yaml:"default,omitempty"`
+	Default Resources `json:"default,omitempty"`
 	// DefaultRequest sets the resource requests for pods without defined resource requests
-	DefaultRequest Resources `yaml:"defaultRequest,omitempty"`
+	DefaultRequest Resources `json:"defaultRequest,omitempty"`
 	// MaxLimitRequestRatio set the max limit request ratio
-	MaxLimitRequestRatio Resources `yaml:"maxLimitRequestRatio,omitempty"`
-	Type                 string    `yaml:"type"`
+	MaxLimitRequestRatio Resources `json:"maxLimitRequestRatio,omitempty"`
+	Type                 string    `json:"type"`
 }
 
 // Limits type
@@ -41,31 +41,31 @@ type Limits []Limit
 // quota type
 type Quotas struct {
 	// Pods is the pods quota
-	Pods string `yaml:"pods,omitempty"`
+	Pods string `json:"pods,omitempty"`
 	// CPULimits is the CPU quota
-	CPULimits string `yaml:"limits.cpu,omitempty"`
+	CPULimits string `json:"limits.cpu,omitempty"`
 	// CPURequests is the CPU requests quota
-	CPURequests string `yaml:"requests.cpu,omitempty"`
+	CPURequests string `json:"requests.cpu,omitempty"`
 	// MemoryLimits is the memory quota
-	MemoryLimits string `yaml:"limits.memory,omitempty"`
+	MemoryLimits string `json:"limits.memory,omitempty"`
 	// MemoryRequests is the memory requests quota
-	MemoryRequests string `yaml:"requests.memory,omitempty"`
+	MemoryRequests string `json:"requests.memory,omitempty"`
 	// CustomResource is a list of custom resource quotas
-	CustomQuotas []CustomResource `yaml:"customQuotas,omitempty"`
+	CustomQuotas []CustomResource `json:"customQuotas,omitempty"`
 }
 
 // Namespace type represents the fields of a Namespace
 type Namespace struct {
 	// Protected if set to true no changes can be applied to the namespace
-	Protected bool `yaml:"protected"`
+	Protected bool `json:"protected"`
 	// Limits to set on the namespace
-	Limits Limits `yaml:"limits,omitempty"`
+	Limits Limits `json:"limits,omitempty"`
 	// Labels to set to the namespace
-	Labels map[string]string `yaml:"labels,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
 	// Annotations to set on the namespace
-	Annotations map[string]string `yaml:"annotations,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 	// Quotas to set on the namespace
-	Quotas   *Quotas `yaml:"quotas,omitempty"`
+	Quotas   *Quotas `json:"quotas,omitempty"`
 	disabled bool
 }
 

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -11,53 +11,53 @@ import (
 // Release type representing Helm releases which are described in the desired state
 type Release struct {
 	// Name is the helm release name
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 	// Description is a user friendly description of the helm release
-	Description string `yaml:"description,omitempty"`
+	Description string `json:"description,omitempty"`
 	// Namespace where to deploy the helm release
-	Namespace string `yaml:"namespace"`
+	Namespace string `json:"namespace"`
 	// Enabled can be used to togle a helm release
-	Enabled bool   `yaml:"enabled"`
-	Group   string `yaml:"group,omitempty"`
-	Chart   string `yaml:"chart"`
+	Enabled bool   `json:"enabled"`
+	Group   string `json:"group,omitempty"`
+	Chart   string `json:"chart"`
 	// Version of the helm chart to deploy
-	Version string `yaml:"version"`
+	Version string `json:"version"`
 	// ValuesFile is the path for a values file for the helm release
-	ValuesFile string `yaml:"valuesFile,omitempty"`
+	ValuesFile string `json:"valuesFile,omitempty"`
 	// ValuesFiles is a list of paths a values files for the helm release
-	ValuesFiles []string `yaml:"valuesFiles,omitempty"`
+	ValuesFiles []string `json:"valuesFiles,omitempty"`
 	// SecretsFile is the path for an encrypted values file for the helm release
-	SecretsFile string `yaml:"secretsFile,omitempty"`
+	SecretsFile string `json:"secretsFile,omitempty"`
 	// SecretsFiles is a list of paths for encrypted values files for the helm release
-	SecretsFiles []string `yaml:"secretsFiles,omitempty"`
+	SecretsFiles []string `json:"secretsFiles,omitempty"`
 	// PostRenderer is the path to an executable to be used for post rendering
-	PostRenderer string `yaml:"postRenderer,omitempty"`
+	PostRenderer string `json:"postRenderer,omitempty"`
 	// Test indicates if the chart tests should be executed
-	Test bool `yaml:"test,omitempty"`
+	Test bool `json:"test,omitempty"`
 	// Protected defines if the release should be protected against changes
-	Protected bool `yaml:"protected,omitempty"`
+	Protected bool `json:"protected,omitempty"`
 	// Wait defines whether helm should block execution until all k8s resources are in a ready state
-	Wait bool `yaml:"wait,omitempty"`
+	Wait bool `json:"wait,omitempty"`
 	// Priority allows defining the execution order, releases with the same priority can be executed in parallel
-	Priority int `yaml:"priority,omitempty"`
+	Priority int `json:"priority,omitempty"`
 	// Set can be used to overwrite the chart values
-	Set map[string]string `yaml:"set,omitempty"`
+	Set map[string]string `json:"set,omitempty"`
 	// SetString can be used to overwrite string values
-	SetString map[string]string `yaml:"setString,omitempty"`
+	SetString map[string]string `json:"setString,omitempty"`
 	// SetFile can be used to overwrite the chart values
-	SetFile map[string]string `yaml:"setFile,omitempty"`
+	SetFile map[string]string `json:"setFile,omitempty"`
 	// HelmFlags is a list of additional flags to pass to the helm command
-	HelmFlags []string `yaml:"helmFlags,omitempty"`
+	HelmFlags []string `json:"helmFlags,omitempty"`
 	// HelmDiffFlags is a list of cli flags to pass to helm diff
-	HelmDiffFlags []string `yaml:"helmDiffFlags,omitempty"`
+	HelmDiffFlags []string `json:"helmDiffFlags,omitempty"`
 	// NoHooks can be used to disable the execution of helm hooks
-	NoHooks bool `yaml:"noHooks,omitempty"`
+	NoHooks bool `json:"noHooks,omitempty"`
 	// Timeout is the number of seconds to wait for the release to complete
-	Timeout int `yaml:"timeout,omitempty"`
+	Timeout int `json:"timeout,omitempty"`
 	// Hooks can be used to define lifecycle hooks specific to this release
-	Hooks map[string]interface{} `yaml:"hooks,omitempty"`
+	Hooks map[string]interface{} `json:"hooks,omitempty"`
 	// MaxHistory is the maximum number of histoical releases to keep
-	MaxHistory int `yaml:"maxHistory,omitempty"`
+	MaxHistory int `json:"maxHistory,omitempty"`
 	disabled   bool
 }
 

--- a/internal/app/spec_state.go
+++ b/internal/app/spec_state.go
@@ -3,15 +3,15 @@ package app
 import (
 	"io/ioutil"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 type StatePath struct {
-	Path string `yaml:"path"`
+	Path string `json:"path"`
 }
 
 type StateFiles struct {
-	StateFiles []StatePath `yaml:"stateFiles"`
+	StateFiles []StatePath `json:"stateFiles"`
 }
 
 // specFromYAML reads a yaml file and decodes it to a state type.

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -13,65 +13,65 @@ import (
 // Config type represents the settings fields
 type Config struct {
 	// KubeContext is the kube context you want Helmsman to use or create
-	KubeContext string `yaml:"kubeContext,omitempty"`
+	KubeContext string `json:"kubeContext,omitempty"`
 	// Username to be used for kubectl credentials
-	Username string `yaml:"username,omitempty"`
+	Username string `json:"username,omitempty"`
 	// Password to be used for kubectl credentials
-	Password string `yaml:"password,omitempty"`
+	Password string `json:"password,omitempty"`
 	// ClusterURI is the URI for your cluster API or the name of an environment variable (starting with `$`) containing the URI
-	ClusterURI string `yaml:"clusterURI,omitempty"`
+	ClusterURI string `json:"clusterURI,omitempty"`
 	// ServiceAccount to be used for tiller (deprecated)
-	ServiceAccount string `yaml:"serviceAccount,omitempty"`
+	ServiceAccount string `json:"serviceAccount,omitempty"`
 	// StorageBackend indicates the storage backened used by helm, defaults to secret
-	StorageBackend string `yaml:"storageBackend,omitempty"`
+	StorageBackend string `json:"storageBackend,omitempty"`
 	// SlackWebhook is the slack webhook URL for slack notifications
-	SlackWebhook string `yaml:"slackWebhook,omitempty"`
+	SlackWebhook string `json:"slackWebhook,omitempty"`
 	// MSTeamsWebhook is the Microsoft teams webhook URL for teams notifications
-	MSTeamsWebhook string `yaml:"msTeamsWebhook,omitempty"`
+	MSTeamsWebhook string `json:"msTeamsWebhook,omitempty"`
 	// ReverseDelete indicates if the applications should be deleted in reverse orderin relation to the installation order
-	ReverseDelete bool `yaml:"reverseDelete,omitempty"`
+	ReverseDelete bool `json:"reverseDelete,omitempty"`
 	// BearerToken indicates whether you want helmsman to connect to the cluster using a bearer token
-	BearerToken bool `yaml:"bearerToken,omitempty"`
+	BearerToken bool `json:"bearerToken,omitempty"`
 	// BearerTokenPath allows specifying a custom path for the token
-	BearerTokenPath string `yaml:"bearerTokenPath,omitempty"`
+	BearerTokenPath string `json:"bearerTokenPath,omitempty"`
 	// NamespaceLabelsAuthoritativei indicates whether helmsman should remove namespace labels that are not in the DSF
-	NamespaceLabelsAuthoritative bool `yaml:"namespaceLabelsAuthoritative,omitempty"`
+	NamespaceLabelsAuthoritative bool `json:"namespaceLabelsAuthoritative,omitempty"`
 	// EyamlEnabled indicates whether eyaml is used for encrypted files
-	EyamlEnabled bool `yaml:"eyamlEnabled,omitempty"`
+	EyamlEnabled bool `json:"eyamlEnabled,omitempty"`
 	// EyamlPrivateKeyPath is the path to the eyaml private key
-	EyamlPrivateKeyPath string `yaml:"eyamlPrivateKeyPath,omitempty"`
+	EyamlPrivateKeyPath string `json:"eyamlPrivateKeyPath,omitempty"`
 	// EyamlPublicKeyPath is the path to the eyaml public key
-	EyamlPublicKeyPath string `yaml:"eyamlPublicKeyPath,omitempty"`
+	EyamlPublicKeyPath string `json:"eyamlPublicKeyPath,omitempty"`
 	// GlobalHooks is a set of global lifecycle hooks
-	GlobalHooks map[string]interface{} `yaml:"globalHooks,omitempty"`
+	GlobalHooks map[string]interface{} `json:"globalHooks,omitempty"`
 	// GlobalMaxHistory sets the global max number of historical release revisions to keep
-	GlobalMaxHistory int `yaml:"globalMaxHistory,omitempty"`
+	GlobalMaxHistory int `json:"globalMaxHistory,omitempty"`
 	// SkipIgnoredApps if set to true, ignored apps will not be considered in the plan
-	SkipIgnoredApps bool `yaml:"skipIgnoredApps,omitempty"`
+	SkipIgnoredApps bool `json:"skipIgnoredApps,omitempty"`
 	// SkipPendingApps is set to true,apps in a pending state will be ignored
-	SkipPendingApps bool `yaml:"skipPendingApps,omitempty"`
+	SkipPendingApps bool `json:"skipPendingApps,omitempty"`
 }
 
 // State type represents the desired State of applications on a k8s cluster.
 type State struct {
 	// Metadata for human reader of the desired state file
-	Metadata map[string]string `yaml:"metadata,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 	// Certificates are used to connect kubectl to a cluster
-	Certificates map[string]string `yaml:"certificates,omitempty"`
+	Certificates map[string]string `json:"certificates,omitempty"`
 	// Settings for configuring helmsman
-	Settings Config `yaml:"settings,omitempty"`
+	Settings Config `json:"settings,omitempty"`
 	// Context defines an helmsman scope
-	Context string `yaml:"context,omitempty"`
+	Context string `json:"context,omitempty"`
 	// HelmRepos from where to find the application helm charts
-	HelmRepos map[string]string `yaml:"helmRepos,omitempty"`
+	HelmRepos map[string]string `json:"helmRepos,omitempty"`
 	// PreconfiguredHelmRepos is a list of helm repos that are configured outside of the DSF
-	PreconfiguredHelmRepos []string `yaml:"preconfiguredHelmRepos,omitempty"`
+	PreconfiguredHelmRepos []string `json:"preconfiguredHelmRepos,omitempty"`
 	// Namespaces where helmsman will deploy applications
-	Namespaces map[string]*Namespace `yaml:"namespaces"`
+	Namespaces map[string]*Namespace `json:"namespaces"`
 	// Apps holds the configuration for each helm release managed by helmsman
-	Apps map[string]*Release `yaml:"apps"`
+	Apps map[string]*Release `json:"apps"`
 	// AppsTemplates allow defining YAML objects thatcan be used as a reference with YAML anchors to keep the configuration DRY
-	AppsTemplates map[string]*Release `yaml:"appsTemplates,omitempty"`
+	AppsTemplates map[string]*Release `json:"appsTemplates,omitempty"`
 	targetMap     map[string]bool
 	chartInfo     map[string]map[string]*ChartInfo
 }

--- a/internal/app/state_files.go
+++ b/internal/app/state_files.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/imdario/mergo"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // invokes either yaml or toml parser considering file extension
@@ -64,25 +64,15 @@ func (s *State) fromTOML(file string) error {
 func (s *State) toTOML(file string) {
 	log.Info("Printing generated toml ... ")
 	var buff bytes.Buffer
-	var (
-		newFile *os.File
-		err     error
-	)
 
 	if err := toml.NewEncoder(&buff).Encode(s); err != nil {
 		log.Fatal(err.Error())
 		os.Exit(1)
 	}
-	newFile, err = os.Create(file)
-	if err != nil {
+	if err := os.WriteFile(file, buff.Bytes(), 0644); err != nil {
 		log.Fatal(err.Error())
 	}
-	bytesWritten, err := newFile.Write(buff.Bytes())
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	log.Info(fmt.Sprintf("Wrote %d bytes.\n", bytesWritten))
-	newFile.Close()
+	log.Info(fmt.Sprintf("Wrote to %s.\n", file))
 }
 
 // fromYAML reads a yaml file and decodes it to a state type.
@@ -114,26 +104,16 @@ func (s *State) fromYAML(file string) error {
 // toYaml encodes a state type into a YAML file
 func (s *State) toYAML(file string) {
 	log.Info("Printing generated yaml ... ")
-	var buff bytes.Buffer
-	var (
-		newFile *os.File
-		err     error
-	)
 
-	if err := yaml.NewEncoder(&buff).Encode(s); err != nil {
+	ymlBytes, err := yaml.Marshal(s)
+	if err != nil {
 		log.Fatal(err.Error())
 		os.Exit(1)
 	}
-	newFile, err = os.Create(file)
-	if err != nil {
+	if err := os.WriteFile(file, ymlBytes, 0644); err != nil {
 		log.Fatal(err.Error())
 	}
-	bytesWritten, err := newFile.Write(buff.Bytes())
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	log.Info(fmt.Sprintf("Wrote %d bytes.\n", bytesWritten))
-	newFile.Close()
+	log.Info(fmt.Sprintf("Wrote to %s.\n", file))
 }
 
 func (s *State) build(files fileOptionArray) error {

--- a/schema.json
+++ b/schema.json
@@ -131,6 +131,13 @@
       ],
       "description": "Limit represents a resource limit"
     },
+    "Limits": {
+      "items": {
+        "$ref": "#/$defs/Limit"
+      },
+      "type": "array",
+      "description": "Limits type"
+    },
     "Namespace": {
       "properties": {
         "protected": {
@@ -138,10 +145,7 @@
           "description": "Protected if set to true no changes can be applied to the namespace"
         },
         "limits": {
-          "items": {
-            "$ref": "#/$defs/Limit"
-          },
-          "type": "array",
+          "$ref": "#/$defs/Limits",
           "description": "Limits to set on the namespace"
         },
         "labels": {


### PR DESCRIPTION
Since https://github.com/invopop/jsonschema/pull/23 was merged `jsonschema` no longer supports `yaml` tags,  and we've updated to that version in https://github.com/Praqma/helmsman/pull/682,  we'd need to add addition json tags to keep using go-yaml, we can avoid duplicate YAML and JSON tags by using `sigs.k8s.io/yaml` that first converts YAML to JSON using go-yaml and then uses `json.Marshal` and `json.Unmarshal` to convert to or from the struct. This means that it effectively reuses the JSON struct tags as well as the custom JSON methods `MarshalJSON` and `UnmarshalJSON` unlike go-yaml.