### PR TITLE
exit when env variables substitution fails

### DIFF
--- a/internal/app/logging.go
+++ b/internal/app/logging.go
@@ -30,11 +30,6 @@ func (l *Logger) Error(message string) {
 	l.Logger.Error(message)
 }
 
-func (l *Logger) Critical(message string) {
-	l.notifyAboutFailureUsingWebhooks(message)
-	l.Logger.Critical(message)
-}
-
 func (l *Logger) Fatal(message string) {
 	l.notifyAboutFailureUsingWebhooks(message)
 	l.Logger.Fatal(message)

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -57,7 +57,7 @@ func substituteVarsInYaml(file string) string {
 	yamlFile := string(rawYamlFile)
 	if !flags.noEnvSubst && flags.substEnvValues {
 		if err := validateEnvVars(yamlFile, file); err != nil {
-			log.Critical(err.Error())
+			log.Fatal(err.Error())
 		}
 		yamlFile = substituteEnv(yamlFile)
 	}
@@ -207,7 +207,7 @@ func validateEnvVars(s string, filename string) error {
 			}
 		}
 		if err := scanner.Err(); err != nil {
-			log.Critical(err.Error())
+			log.Fatal(err.Error())
 		}
 	}
 	return nil


### PR DESCRIPTION
### What
- use `log.Fatal()` if there is a environment variables substitution validation error in values file instead of `log.Critical()`
- use `log.Fatal()` if there is an error while reading a values file
- remove `Critical` method from `Logger` as unused function

### Why
When Helmsman validates values files and one of the environment variables is unset, it writes a log message with a critical level to the stdout, **but** doesn't interrupt execution. This behavior seems unintended, and might lead to situation when a misconfigured chart gets installed into a k8s cluster.


### Example
Given:

**charts/charts.yaml**
```yaml
helmRepos:
  jenkins: https://charts.jenkins.io

namespaces:
  staging:

apps:
  jenkins:
    namespace: staging
    enabled: true
    chart: jenkins/jenkins
    version: 2.15.1
    valuesFile: ./jenkins.yaml
```

**charts/jenkins.yaml**
```yaml
# JENKINS_IMAGE is unset
image: ${JENKINS_IMAGE}
```


#### Current behavior
```
➜ helmsman -subst-env-values -f charts/charts.yaml
2022-08-22 10:36:37 INFO: validating environment variables in charts/charts.yaml
2022-08-22 10:36:37 INFO: Parsed [[ charts/charts.yaml ]] successfully and found [ 2 ] apps
2022-08-22 10:36:37 INFO: validating environment variables in /Users/alex.prizov/github.com/prizov/helmsman/charts/jenkins.yaml
2022-08-22 10:36:37 CRITICAL: ${JENKINS_IMAGE} is used as an env variable but is currently unset. Either set it or escape it like so: $${JENKINS_IMAGE}
2022-08-22 10:36:37 INFO: Validating desired state definition
2022-08-22 10:36:37 INFO: Setting up kubectl
2022-08-22 10:36:37 INFO: Setting up helm
2022-08-22 10:36:42 INFO: Getting chart information
2022-08-22 10:36:44 INFO: Charts validated.
2022-08-22 10:36:44 INFO: Preparing plan
2022-08-22 10:36:44 INFO: Acquiring current Helm state from cluster
2022-08-22 10:36:44 INFO: Checking if any Helmsman managed releases are no longer tracked by your desired state ...
2022-08-22 10:36:45 INFO: No untracked releases found
2022-08-22 10:36:45 NOTICE: -------- PLAN starts here --------------
2022-08-22 10:36:45 NOTICE: Release [ jenkins ] in namespace [ staging ] will be installed using version [ 2.15.1 ] -- priority: 0
2022-08-22 10:36:45 NOTICE: Release [ artifactory ] in namespace [ staging ] will be installed using version [ 11.4.2 ] -- priority: 0
2022-08-22 10:36:45 NOTICE: -------- PLAN ends here --------------

➜ echo $?
0 


``` 


#### With proposed changes
```
➜ helmsman -subst-env-values -f charts/charts.yaml
2022-08-22 10:47:09 INFO: Parsed [[ charts/charts.yaml ]] successfully and found [ 1 ] apps
2022-08-22 10:47:09 INFO: validating environment variables in /Users/alex.prizov/github.com/prizov/helmsman/charts/jenkins.yaml
2022-08-22 10:47:09 CRITICAL: ${JENKINS_IMAGE} is used as an env variable but is currently unset. Either set it or escape it like so: $${JENKINS_IMAGE}

➜ echo $?
1
```