### PR TITLE
kube_helpers.go: don't look for context when SQL backend is used

### DIFF
--- a/internal/app/kube_helpers.go
+++ b/internal/app/kube_helpers.go
@@ -322,15 +322,18 @@ func getReleaseContext(releaseName, namespace, storageBackend string) string {
 	// kubectl get secrets -n test1 -l MANAGED-BY=HELMSMAN -o=jsonpath='{.items[0].metadata.labels.HELMSMAN_CONTEXT}'
 	// kubectl get secret sh.helm.release.v1.argo.v1  -n test1  -o=jsonpath='{.metadata.labels.HELMSMAN_CONTEXT}'
 	// kubectl get secret -l owner=helm,name=argo -n test1 -o=jsonpath='{.items[-1].metadata.labels.HELMSMAN_CONTEXT}'
-	cmd := kubectl([]string{"get", storageBackend, "-n", namespace, "-l", "owner=helm", "-l", "name=" + releaseName, "-o", "jsonpath='{.items[-1].metadata.labels.HELMSMAN_CONTEXT}'"}, "Getting Helmsman context for [ "+releaseName+" ] release")
+	rctx := defaultContextName
+	if storageBackend != "sql" {
+		cmd := kubectl([]string{"get", storageBackend, "-n", namespace, "-l", "owner=helm", "-l", "name=" + releaseName, "-o", "jsonpath='{.items[-1].metadata.labels.HELMSMAN_CONTEXT}'"}, "Getting Helmsman context for [ "+releaseName+" ] release")
 
-	res, err := cmd.Exec()
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	rctx := strings.Trim(res.output, `"' `)
-	if rctx == "" {
-		rctx = defaultContextName
+		res, err := cmd.Exec()
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		ctx := strings.Trim(res.output, `"' `)
+		if ctx != "" {
+			rctx = ctx
+		}
 	}
 	return rctx
 }


### PR DESCRIPTION
Helm supports using a PostgreSQL database as the storage backend, rather than k8s Secrets or ConfigMaps. This is the storage backend that I use, and when I try to use Helmsman with it, I get an error because the kubectl command in this `getReleaseContext` function assumes that either Secrets or ConfigMaps are in use.

My change makes it so that this context check is altogether skipped and the default context is used if the storage backend is set to `sql`. My workaround up to this point has been to create a placeholder secret in each namespace that matches the label selectors that this function uses, but I would rather not have to do that.