### PR TITLE
helm-secrets 4

### DIFF
--- a/internal/app/helm_helpers.go
+++ b/internal/app/helm_helpers.go
@@ -100,6 +100,29 @@ func helmPluginExists(plugin string) bool {
 	return strings.Contains(res.output, plugin)
 }
 
+func getHelmPlugVersion(plugin string) string {
+	cmd := helmCmd([]string{"plugin", "list"}, "Validating that [ "+plugin+" ] is installed")
+
+	res, err := cmd.Exec()
+	if err != nil {
+		return "0.0.0"
+	}
+	for _, line := range strings.Split(strings.TrimSuffix(res.output, "\n"), "\n") {
+		info := strings.Fields(line)
+		if len(info) < 2 {
+			continue
+		}
+		if strings.TrimSpace(info[0]) == plugin {
+			return strings.TrimSpace(info[1])
+		}
+	}
+	return "0.0.0"
+}
+
+func checkHelmPlugVersion(plugin, constraint string) bool {
+	return checkVersion(getHelmPlugVersion(plugin), constraint)
+}
+
 // updateChartDep updates dependencies for a local chart
 func updateChartDep(chartPath string) error {
 	cmd := helmCmd([]string{"dependency", "update", "--skip-refresh", chartPath}, "Updating dependency for local chart [ "+chartPath+" ]")

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -476,7 +476,7 @@ func decryptSecret(name string) error {
 	cmd := helmBin
 	args := []string{"secrets", "dec", name}
 	// helm-secrets >=4.0.0 decrypts to stdout, not to a .dec-file
-	useHelmOutput := checkHelmPlugVersion("secrets", ">=4.0.0")
+	useHelmOutput := checkHelmPlugVersion("secrets", ">=4.0.0") || settings.EyamlEnabled
 	if useHelmOutput {
 		args[1] = "decrypt"
 	}
@@ -520,14 +520,12 @@ func decryptSecret(name string) error {
 	if err != nil {
 		return err
 	}
-	if !(settings.EyamlEnabled || useHelmOutput) {
+	if !useHelmOutput {
 		_, fileNotFound := os.Stat(name + ".dec")
 		if fileNotFound != nil && !isOfType(name, []string{".dec"}) {
 			return fmt.Errorf(res.String())
 		}
-	}
-
-	if settings.EyamlEnabled || useHelmOutput {
+	} else {
 		var outfile string
 		if isOfType(name, []string{".dec"}) {
 			outfile = name

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -475,7 +475,9 @@ func writeStringToFile(filename string, data string) error {
 func decryptSecret(name string) error {
 	cmd := helmBin
 	args := []string{"secrets", "dec", name}
-	if checkHelmPlugVersion("secrets", ">=4.0.0") {
+	// helm-secrets >=4.0.0 decrypts to stdout, not to a .dec-file
+	useHelmOutput := checkHelmPlugVersion("secrets", ">=4.0.0")
+	if useHelmOutput {
 		args[1] = "decrypt"
 	}
 
@@ -518,14 +520,14 @@ func decryptSecret(name string) error {
 	if err != nil {
 		return err
 	}
-	if !settings.EyamlEnabled {
+	if !(settings.EyamlEnabled || useHelmOutput) {
 		_, fileNotFound := os.Stat(name + ".dec")
 		if fileNotFound != nil && !isOfType(name, []string{".dec"}) {
 			return fmt.Errorf(res.String())
 		}
 	}
 
-	if settings.EyamlEnabled {
+	if settings.EyamlEnabled || useHelmOutput {
 		var outfile string
 		if isOfType(name, []string{".dec"}) {
 			outfile = name

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -475,6 +475,9 @@ func writeStringToFile(filename string, data string) error {
 func decryptSecret(name string) error {
 	cmd := helmBin
 	args := []string{"secrets", "dec", name}
+	if checkHelmPlugVersion("secrets", ">=4.0.0") {
+		args[1] = "decrypt"
+	}
 
 	if settings.EyamlEnabled {
 		cmd = "eyaml"


### PR DESCRIPTION
Based on #721, but use stdout of helm-secrets directly, like in eyaml. Should fix #715.

- fix: check helm plugin version
- fix: use helm-secrets stdout on newer versions
