### PR TITLE
allow use of metadata server for gcs authentication inside GCP

### DIFF
--- a/docs/how_to/helm_repos/gcs.md
+++ b/docs/how_to/helm_repos/gcs.md
@@ -11,6 +11,8 @@ You need to provide one of the following env variables:
 - `GOOGLE_APPLICATION_CREDENTIALS` environment variable to contain the absolute path to your Google cloud credentials.json file.
 - Or, `GCLOUD_CREDENTIALS` environment variable to contain the content of the credentials.json file.
 
+If running inside GCP helmsman can use metadata server to use Service Account permissions.
+
 Helmsman uses the [helm GCS](https://github.com/nouney/helm-gcs) plugin to work with GCS helm repos.
 
 ```toml

--- a/docs/how_to/misc/auth_to_storage_providers.md
+++ b/docs/how_to/misc/auth_to_storage_providers.md
@@ -21,6 +21,8 @@ You need to provide ONE of the following env variables:
 - `GOOGLE_APPLICATION_CREDENTIALS` the absolute path to your Google cloud credentials.json file.
 - Or, `GCLOUD_CREDENTIALS` the content of the credentials.json file.
 
+If running inside GCP helmsman can use metadata server to use Service Account permissions.
+
 ## Microsoft Azure
 
 You need to provide ALL of the following env variables:


### PR DESCRIPTION
Currently helmsman requires certificate provided via GOOGLE_APPLICATION_CREDENTIALS or GCLOUD_CREDENTIALS environment variable to read charts from GCP.

When running inside GCP helmsman can use metadata server to authenticate as Service Account.

This change prevents helmsman from failing when no env variables are provided, but metadata server is available.

