### PR TITLE
Fix helm-vault secret decryption

### DIFF
--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -526,6 +526,19 @@ func decryptSecret(name string) error {
 		outfile += ".dec"
 	}
 
+	if settings.VaultEnabled {
+		// helm-vault plugin doesn't write to stdout
+		useHelmOutput = false
+		if settings.VaultEnvironment != "" {
+			// helm-vault decryption with an environment interpolate the environment name into the output filename
+			vaultOutFile := name + "." + settings.VaultEnvironment + ".dec"
+			if _, err := os.Stat(vaultOutFile); err != nil {
+				return fmt.Errorf("decrypted vault file not found: %s", vaultOutFile)
+			}
+			os.Rename(vaultOutFile, outfile)
+		}
+	}
+
 	if !useHelmOutput {
 		if _, err := os.Stat(outfile); err != nil {
 			return fmt.Errorf("decryption failed: %s", res.String())


### PR DESCRIPTION
Fixes #758 

- `helm-vault` does not support outputting secrets to stdout, so `useHelmOutput` is set to `false`
- `helm-vault` interpolates the environment variable name into the output file if one is specified, so an additional step of renaming the file to the expected name is added
- `helm-vault` outputs the expected file by default (original file name with `.dec` appended) if no environment is specified. No changes required to handle this case other than settings `useHelmOutput` to `false`