### PR TITLE
Add support for hiera-eyaml-gkms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN helm plugin install https://github.com/jkroepke/helm-secrets --version ${HEL
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} as builder
 
 RUN apk add --update --no-cache ca-certificates git openssh-client ruby bash make curl
-RUN gem install hiera-eyaml --no-doc
+RUN gem install hiera-eyaml hiera-eyaml-gkms --no-doc
 RUN update-ca-certificates
 
 COPY --from=helm-installer /usr/local/bin/kubectl /usr/local/bin/kubectl
@@ -70,7 +70,7 @@ RUN make test \
 FROM alpine:${ALPINE_VERSION} as base
 
 RUN apk add --update --no-cache ca-certificates git openssh-client ruby curl bash gnupg
-RUN gem install hiera-eyaml --no-doc
+RUN gem install hiera-eyaml hiera-eyaml-gkms --no-doc
 RUN update-ca-certificates
 
 COPY --from=helm-installer /usr/local/bin/kubectl /usr/local/bin/kubectl

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -56,6 +56,16 @@ type Config struct {
 	EyamlPrivateKeyPath string `json:"eyamlPrivateKeyPath,omitempty"`
 	// EyamlPublicKeyPath is the path to the eyaml public key
 	EyamlPublicKeyPath string `json:"eyamlPublicKeyPath,omitempty"`
+	// EyamlGkms indicates whether to use GKMS for eyaml
+	EyamlGkms bool `json:"eyamlGkms,omitepty"`
+	// EyamlGkmsProject is the GCP project where GKMS keys are stored
+	EyamlGkmsProject string `json:"eyamlGkmsProject,omitempty"`
+	// EyamlGkmsLocation is the KMS location
+	EyamlGkmsLocation string `json:"eyamlGkmsLocation,omitempty"`
+	// EyamlGkmsKeyring is the ID of the Cloud KMS key ring
+	EyamlGkmsKeyring string `json:"eyamlGkmsKeyring,omitempty"`
+	// EyamlGkmsCryptoKey is the ID of the key to use
+	EyamlGkmsCryptoKey string `json:"eyamlGkmsCryptoKey,omitempty"`
 	// GlobalHooks is a set of global lifecycle hooks
 	GlobalHooks map[string]interface{} `json:"globalHooks,omitempty"`
 	// GlobalMaxHistory sets the global max number of historical release revisions to keep
@@ -221,7 +231,12 @@ func (s *State) validate() error {
 	if (s.Settings.EyamlPrivateKeyPath != "" && s.Settings.EyamlPublicKeyPath == "") || (s.Settings.EyamlPrivateKeyPath == "" && s.Settings.EyamlPublicKeyPath != "") {
 		return errors.New("both EyamlPrivateKeyPath and EyamlPublicKeyPath are required")
 	}
-
+	
+	if s.Settings.EyamlGkms {
+		if (s.Settings.EyamlGkmsProject == "" || s.Settings.EyamlGkmsLocation == "" || s.Settings.EyamlGkmsKeyring == "" || s.Settings.EyamlGkmsCryptoKey == "") {
+			return errors.New("all arguments are required: EyamlGkmsProject, EyamlGkmsLocation, EyamlGkmsKeyring, EyamlGkmsCryptoKey")
+		}
+	}
 	// namespaces
 	if flags.nsOverride == "" {
 		if s.Namespaces == nil || len(s.Namespaces) == 0 {

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -484,7 +484,11 @@ func decryptSecret(name string) error {
 	if settings.EyamlEnabled {
 		cmd = "eyaml"
 		args = []string{"decrypt", "-f", name}
-		if settings.EyamlPrivateKeyPath != "" && settings.EyamlPublicKeyPath != "" {
+		if settings.EyamlGkms {
+			if settings.EyamlGkmsProject != "" && settings.EyamlGkmsLocation != "" && settings.EyamlGkmsKeyring != "" && settings.EyamlGkmsCryptoKey != "" {
+				args = append(args, []string{"--gkms-auth-type", "default", "--gkms-project", settings.EyamlGkmsProject, "--gkms-location", settings.EyamlGkmsLocation, "--gkms-keyring", settings.EyamlGkmsKeyring, "--gkms-crypto-key", settings.EyamlGkmsCryptoKey}...)
+			}
+		} else if settings.EyamlPrivateKeyPath != "" && settings.EyamlPublicKeyPath != "" {
 			args = append(args, []string{"--pkcs7-private-key", settings.EyamlPrivateKeyPath, "--pkcs7-public-key", settings.EyamlPublicKeyPath}...)
 		}
 	} else if settings.VaultEnabled {

--- a/schema.json
+++ b/schema.json
@@ -93,6 +93,26 @@
           "type": "string",
           "description": "EyamlPublicKeyPath is the path to the eyaml public key"
         },
+        "eyamlGkms": {
+          "type": "boolean",
+          "description": "EyamlGkms indicates whether to use GKMS for eyaml"
+        },
+        "eyamlGkmsProject": {
+          "type": "string",
+          "description": "EyamlGkmsProject is the GCP project where GKMS keys are stored"
+        },
+        "eyamlGkmsLocation": {
+          "type": "string",
+          "description": "EyamlGkmsLocation is the KMS location"
+        },
+        "eyamlGkmsKeyring": {
+          "type": "string",
+          "description": "EyamlGkmsKeyring is the ID of the Cloud KMS key ring"
+        },
+        "eyamlGkmsCryptoKey": {
+          "type": "string",
+          "description": "EyamlGkmsCryptoKey is the ID of the key to use"
+        },
         "globalHooks": {
           "type": "object",
           "description": "GlobalHooks is a set of global lifecycle hooks"


### PR DESCRIPTION
I have noticed, that helmsman supports `hiera-eyaml` with only local PKCS7 keys for secrets. This PR adds support for Google Cloud KMS in `hiera-eyaml`.

Currently, helmsman only supports `hiera-eyaml` with local PKCS7 keys for secrets. This limits users who want to manage their keys differently.

I have made a code changes to add support for `hiera-eyaml-gkms`, which is a plugin for `hiera-eyaml `that extends default `hiera-eyaml` functionalities. This will allow users to encrypt and decrypt secrets using GKMS keys stored in GCP. Users can specify the project id, keyring and crypto-key they are referring to.

These change will add a valuable feature to helmsman allowing users to use different method and can be a starting point to include also different cloud providers for `heira-eyaml`.