### PR TITLE
Fix issue with hiera-eyaml-gkms encrypt/decrypt actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN make test \
 ### Final Image ###
 FROM alpine:${ALPINE_VERSION} as base
 
-RUN apk add --update --no-cache ca-certificates git openssh-client ruby curl bash gnupg
+RUN apk add --update --no-cache ca-certificates git openssh-client ruby curl bash gnupg gcompat
 RUN gem install hiera-eyaml hiera-eyaml-gkms --no-doc
 RUN update-ca-certificates
 


### PR DESCRIPTION
I found issue when encrypting/decrypting secrets with hiera-eyaml using GKMS in docker container. eyaml fails with error message:
```
Error loading shared library ld-linux-x86-64.so.2
```

Issue resolved by adding `gcompat` package.