### PR TITLE
Update README.md v3.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ Check the [releases page](https://github.com/Praqma/Helmsman/releases) for the d
 
 ```sh
 # on Linux
-curl -L https://github.com/Praqma/helmsman/releases/download/v3.11.0/helmsman_3.11.0_linux_amd64.tar.gz | tar zx
+curl -L https://github.com/Praqma/helmsman/releases/download/v3.17.0/helmsman_3.17.0_linux_amd64.tar.gz | tar zx
 # on MacOS
-curl -L https://github.com/Praqma/helmsman/releases/download/v3.11.0/helmsman_3.11.0_darwin_amd64.tar.gz | tar zx
+curl -L https://github.com/Praqma/helmsman/releases/download/v3.17.0/helmsman_3.17.0_darwin_amd64.tar.gz | tar zx
 
 mv helmsman /usr/local/bin/helmsman
 ```


### PR DESCRIPTION
Update installation commands to use the latest version. Version 3.11.0 does not work anymore with the latest versions of kubectl due to the deprecation of the `--short` flag on `kubectl version`.

Maybe this can be automated in the future using a GitHub action?