### PR TITLE
feat: add show-secrets option

### DIFF
--- a/internal/app/cli.go
+++ b/internal/app/cli.go
@@ -98,6 +98,7 @@ type cli struct {
 	skipIgnoredApps       bool
 	skipPendingApps       bool
 	pendingAppRetries     int
+	showSecrets           bool
 }
 
 func printUsage() {
@@ -155,6 +156,7 @@ func (c *cli) setup() {
 	flag.BoolVar(&c.skipIgnoredApps, "skip-ignored", false, "skip ignored apps")
 	flag.BoolVar(&c.skipPendingApps, "skip-pending", false, "skip pending helm releases")
 	flag.IntVar(&c.pendingAppRetries, "pending-max-retries", 0, "max number of retries for pending helm releases")
+	flag.BoolVar(&c.showSecrets, "show-secrets", false, "show helm diff results with secrets.")
 	flag.Usage = printUsage
 	flag.Parse()
 }

--- a/internal/app/release.go
+++ b/internal/app/release.go
@@ -195,7 +195,10 @@ func (r *Release) diff() (string, error) {
 	)
 
 	if !flags.kubectlDiff {
-		args = []string{"diff", "--suppress-secrets"}
+		args = []string{"diff"}
+		if !flags.showSecrets {
+			args = append(args, "--suppress-secrets")
+		}
 		if flags.noColors {
 			args = append(args, "--no-color")
 		}


### PR DESCRIPTION
Add the ability to show secrets when diffing, via `--show-secrets`. Default to off of course